### PR TITLE
Add german locale

### DIFF
--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1,4 +1,4 @@
-en:
+de:
   js:
     action_codes:
       assigned: "zugeordnet %{who} %{when}"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1,0 +1,19 @@
+en:
+  js:
+    action_codes:
+      assigned: "zugeordnet %{who} %{when}"
+      unassigned: "Zuordnung aufgehoben %{who} %{when}"
+    discourse_assign:
+      assigned: "Zugeordnet"
+      assign_html: "<p class='assigned-to'><i class='fa-user-plus fa'></i> Zugeordnet zu {{userLink}}</p>"
+      assign_notification: "<i title='assigned' class='fa fa-user-plus'></i><p><span>{{username}}</span> {{description}}</p>"
+      unassign:
+        title: "Zuordnung aufheben"
+        help: "Zuordnung der Person zum Thema aufheben"
+      assign:
+        title: "Zuordnen"
+        help: "Thema einer Person zuordnen"
+      assign_modal:
+        title: "Thema zuordnen"
+        description: "Gib den Benutzernamen der Person ein, der du dieses Thema zuordnen möchtest"
+        assign: "Zuordnen"

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -1,4 +1,4 @@
-en:
+de:
   site_settings:
     assigns_public: "Zuordnung von Themen öffentlich sichtbar machen"
     assigns_user_url_path: "Pfad zu Themen, die einem Benutzer zugeordnet sind (verwende {username}, um den Benutzernamen zu ersetzen)"

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -1,0 +1,13 @@
+en:
+  site_settings:
+    assigns_public: "Zuordnung von Themen öffentlich sichtbar machen"
+    assigns_user_url_path: "Pfad zu Themen, die einem Benutzer zugeordnet sind (verwende {username}, um den Benutzernamen zu ersetzen)"
+    assigns_by_staff_mention: "Wenn ein Mitarbeiter einen anderen Mitarbeiter erwähnt, wird das Thema automatisch zugeordnet"
+    unassign_creates_tracking_post: "Wenn die Zurordnung aufgehoben wird, zur Nachvollziehbarkeit einen privaten Beitrag oder eine Aktion erstellen"
+    assign_self_regex: "Regulärer Ausdruck, der erfüllt sein muss, um sich einem Thema selbst zuzuordnen. Beispiel: 'meine Liste'."
+    assign_other_regex: "Regulärer Ausdruck, der erfüllt sein muss, um ein Thema jemand anderen zuzordnen. Beispiel: 'deine Liste'"
+    unassign_on_group_archive: "Zuordnung aufheben, wenn eine Nachricht von einer Gruppe archiviert worden ist (Wieder zuordnen, wenn in den Posteingang verschoben)"
+    unassign_on_close: "Wenn das Thema geschlossen wird, hebe die Zuordnung der Person zum Thema auf"
+  discourse_assign:
+    assigned_to: "Thema zugeordnet zu @%{username}"
+    unassigned: "Zuordnung zum Thema wurde aufgehoben"


### PR DESCRIPTION
I translated the "assign" with "zuordnen" rather than "zuweisen", which sounds a little too much like a commanding tone. Sadly, in any variant there will be two words for the translation of "unassign" ("Zuordnung aufheben"). This lets the assign button become equally wide as the bookmark button. However, it seems to fit and is not too ugly (see screenshot)

<img width="1166" alt="bildschirmfoto 2017-03-09 um 16 43 02" src="https://cloud.githubusercontent.com/assets/3115618/23757603/9a812a80-04e7-11e7-8ebd-3769dfad19d3.png">

The rest of the texts are as short as possible… Sometimes it's hard to write short sentences in German 😄 