### PR TITLE
FEATURE: Limit the amount of assigned topics an user can have.

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -3,7 +3,7 @@ module DiscourseAssign
     before_action :ensure_logged_in
 
     def suggestions
-      users = TopicAssigner.can_assign_to?(current_user) ? [current_user] : []
+      users = [current_user]
       users += User
         .where('admin OR moderator')
         .where('users.id <> ?', current_user.id)

--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -3,17 +3,20 @@ module DiscourseAssign
     before_action :ensure_logged_in
 
     def suggestions
-      users = [current_user]
+      users = TopicAssigner.can_assign_to?(current_user) ? [current_user] : []
       users += User
         .where('admin OR moderator')
         .where('users.id <> ?', current_user.id)
-        .joins("join (
-                       SELECT value::integer user_id, MAX(created_at) last_assigned
-                       FROM topic_custom_fields
-                       WHERE name = 'assigned_to_id'
-                       GROUP BY value::integer
-                      ) as X ON X.user_id = users.id")
-        .order('X.last_assigned DESC')
+        .joins(<<~SQL
+          JOIN(
+                SELECT value::integer user_id, MAX(created_at) last_assigned
+                FROM topic_custom_fields
+                WHERE name = 'assigned_to_id'
+                GROUP BY value::integer
+                HAVING COUNT(*) < #{SiteSetting.max_assigned_topics}
+              ) as X ON X.user_id = users.id
+        SQL
+        ).order('X.last_assigned DESC')
         .limit(6)
 
       render json: ActiveModel::ArraySerializer.new(users,
@@ -62,23 +65,32 @@ module DiscourseAssign
 
       raise Discourse::NotFound unless assign_to
 
-      if topic.custom_fields && topic.custom_fields['assigned_to_id'] == assign_to.id.to_s
-        return render json: { failed: I18n.t('discourse_assign.already_assigned', username: username) }, status: 400
-      end
-
-      assigner = TopicAssigner.new(topic, current_user)
-
       # perhaps?
       #Scheduler::Defer.later "assign topic" do
-      assigner.assign(assign_to)
+      assign = TopicAssigner.new(topic, current_user).assign(assign_to)
 
-      render json: success_json
+      if assign[:success]
+        render json: success_json
+      else
+        render json: translate_failure(assign[:reason], assign_to), status: 400
+      end
     end
 
     def unassign_all
       user = User.find_by(id: params[:user_id])
       TopicAssigner.unassign_all(user, current_user)
       render json: success_json
+    end
+
+    private
+
+    def translate_failure(reason, user)
+      if reason == :already_assigned
+        { error: I18n.t('discourse_assign.already_assigned', username: user.username) }
+      else
+        max = SiteSetting.max_assigned_topics
+        { error: I18n.t('discourse_assign.too_many_assigns', username: user.username, max: max) }
+      end
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -14,11 +14,13 @@ en:
     flags_require_assign: "When enabled, flags cannot be handled unless assigned to a user."
     remind_assigns: "Remind users about pending assigns."
     remind_assigns_frequency: "Frequency for reminding users about assigned topics."
+    max_assigns_per_user: "Maximum number of topics that can be assigned to a user."
   discourse_assign:
     assigned_to: "Topic assigned to @%{username}"
     unassigned: "Topic was unassigned"
     already_claimed: "That topic has already been claimed."
     already_assigned: 'Topic is already assigned to @%{username}'
+    too_many_assigns: "@%{username} has already reached the maximum number of assigned topics (%{max})."
     flag_assigned: "Sorry, that flag's topic is assigned to another user"
     flag_unclaimed: "You must claim that topic before acting on the flag"
     topic_assigned_excerpt: "assigned you the topic '%{title}'"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,7 @@ plugins:
     client: true
     enum: "RemindAssignsFrequencySiteSettings"
     default: 0
+  max_assigned_topics:
+    client: true
+    default: 10
+    min: 1

--- a/lib/topic_assigner.rb
+++ b/lib/topic_assigner.rb
@@ -121,11 +121,6 @@ SQL
     end
   end
 
-  def self.can_assign_to?(user)
-    assigned_total = TopicCustomField.where(name: ASSIGNED_TO_ID, value: user.id.to_s).count
-    assigned_total < SiteSetting.max_assigned_topics
-  end
-
   def initialize(topic, user)
     @assigned_by = user
     @topic = topic
@@ -135,9 +130,14 @@ SQL
     User.real.staff.pluck(:id)
   end
 
+  def can_assign_to?(user)
+    assigned_total = TopicCustomField.where(name: ASSIGNED_TO_ID, value: user.id.to_s).count
+    assigned_total < SiteSetting.max_assigned_topics || @assigned_by.id == user.id
+  end
+
   def assign(assign_to, silent: false)
     return { success: false, reason: :already_assigned } if @topic.custom_fields && @topic.custom_fields[ASSIGNED_TO_ID] == assign_to.id.to_s
-    return { success: false, reason: :too_many_assigns } unless self.class.can_assign_to?(assign_to)
+    return { success: false, reason: :too_many_assigns } unless can_assign_to?(assign_to)
 
     @topic.custom_fields[ASSIGNED_TO_ID] = assign_to.id
     @topic.custom_fields[ASSIGNED_BY_ID] = @assigned_by.id

--- a/spec/lib/topic_assigner_spec.rb
+++ b/spec/lib/topic_assigner_spec.rb
@@ -132,15 +132,25 @@ RSpec.describe TopicAssigner do
       assigner.assign(moderator).fetch(:success)
     end
 
-    it "Don't assign if the user has too many assigned topics" do
+    it "doesn't assign if the user has too many assigned topics" do
       SiteSetting.max_assigned_topics = 1
       another_post = Fabricate.build(:post)
       assigner.assign(moderator)
 
-      second_assign = TopicAssigner.new(another_post.topic, moderator).assign(moderator)
+      second_assign = TopicAssigner.new(another_post.topic, moderator2).assign(moderator)
 
       expect(second_assign[:success]).to eq(false)
       expect(second_assign[:reason]).to eq(:too_many_assigns)
+    end
+
+    it "doesn't enforce the limit when self-assigning" do
+      SiteSetting.max_assigned_topics = 1
+      another_post = Fabricate(:post)
+      assigner.assign(moderator)
+
+      second_assign = TopicAssigner.new(another_post.topic, moderator).assign(moderator)
+
+      expect(second_assign[:success]).to eq(true)
     end
   end
 

--- a/spec/lib/topic_assigner_spec.rb
+++ b/spec/lib/topic_assigner_spec.rb
@@ -152,6 +152,16 @@ RSpec.describe TopicAssigner do
 
       expect(second_assign[:success]).to eq(true)
     end
+
+    it "doesn't count self-assigns when enforcing the limit" do
+      SiteSetting.max_assigned_topics = 1
+      another_post = Fabricate(:post)
+      TopicAssigner.new(another_post.topic, moderator).assign(moderator)
+
+      second_assign = assigner.assign(moderator)
+
+      expect(second_assign[:success]).to eq(true)
+    end
   end
 
   context "unassign_on_close" do


### PR DESCRIPTION
### Changes

- Move domain validations inside the `TopicAssigner` to avoid duplicating them.
- Expose a `max_assigned_topics` setting.
- Do not assign a topic to a user if it'll exceed this limit.
- Do not suggest users who have already reached the limit.

![Screen Shot 2019-04-25 at 12 36 37](https://user-images.githubusercontent.com/5025816/56753973-2e22cf80-6762-11e9-9870-107eb56b02f8.png)
