### PR TITLE
Disable flagging behaviour in favor of the new reviewable API

### DIFF
--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -75,7 +75,7 @@ describe 'integration tests' do
       )
     end
 
-    it "do not raise error if topic is deleted" do
+    it "do not raise error if topic is deleted", unless: defined?(Reviewable) do
       expect { DiscourseEvent.trigger(:before_staff_flag_action, args) }
         .to raise_error(Discourse::InvalidAccess)
 


### PR DESCRIPTION
This PR bypasses the callbacks defined for `assign_locks_flags` and `flags_require_assign` since the queue was deprecated in favor of the new Reviewable API.

There's no need to change client code since the connectors will never be used (the queue was removed). However, we'll leave them there for backward compatibility reasons.