### PR TITLE
FIX: Staff can always assign

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
@@ -5,8 +5,9 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default Ember.Controller.extend({
   taskActions: Ember.inject.service(),
   assignSuggestions: function() {
-    ajax("/assign/suggestions").then(users => {
-      this.set("assignSuggestions", users);
+    ajax("/assign/suggestions").then(suggestions => {
+      this.set("assignAllowedGroups", suggestions.assign_allowed_groups);
+      this.set("assignSuggestions", suggestions.suggested_users);
     });
   }.property(),
 
@@ -24,7 +25,6 @@ export default Ember.Controller.extend({
   actions: {
     assignUser(user) {
       this.set("model.username", user.username);
-      this.set("model.allowedGroups", this.get("taskActions").allowedGroups);
       this.send("assign");
     },
 

--- a/assets/javascripts/discourse/services/task-actions.js.es6
+++ b/assets/javascripts/discourse/services/task-actions.js.es6
@@ -1,16 +1,7 @@
 import { ajax } from "discourse/lib/ajax";
 import showModal from "discourse/lib/show-modal";
-import { getOwner } from "discourse-common/lib/get-owner";
 
 export default Ember.Service.extend({
-  init() {
-    this._super(...arguments);
-
-    this.allowedGroups = getOwner(this)
-      .lookup("site-settings:main")
-      .assign_allowed_on_groups.split("|");
-  },
-
   unassign(topicId) {
     return ajax("/assign/unassign", {
       type: "PUT",
@@ -22,8 +13,7 @@ export default Ember.Service.extend({
     return showModal("assign-user", {
       model: {
         topic: topic,
-        username: topic.get("assigned_to_user.username"),
-        allowedGroups: this.allowedGroups
+        username: topic.get("assigned_to_user.username")
       }
     });
   }

--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -4,7 +4,7 @@
     single=true
     allowAny=false
     group="staff"
-    groupMembersOf=model.allowedGroups
+    groupMembersOf=assignAllowedGroups
     excludeCurrentUser=false
     includeMentionableGroups=false
     hasGroups=false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,7 +30,7 @@ plugins:
   assign_allowed_on_groups:
     client: true
     type: group_list
+    default: ''
     list_type: compact
-    default: 'staff'
     allow_any: false
     refresh: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -49,6 +49,8 @@ after_initialize do
   reviewable_api_enabled = defined?(Reviewable)
 
   add_to_class(:user, :can_assign?) do
+    return true if staff?
+
     @can_assign ||=
       begin
         allowed_groups = SiteSetting.assign_allowed_on_groups.split('|').compact
@@ -62,11 +64,18 @@ after_initialize do
 
   add_class_method(:user, :assign_allowed) do
     allowed_groups = SiteSetting.assign_allowed_on_groups.split('|')
-    where('users.id IN (
-      SELECT user_id FROM group_users
-      INNER JOIN groups ON group_users.group_id = groups.id
-      WHERE groups.name IN (?)
-    )', allowed_groups)
+
+    if allowed_groups.present?
+      real.where('
+        users.admin OR users.moderator OR
+        users.id IN (
+          SELECT user_id FROM group_users
+          INNER JOIN groups ON group_users.group_id = groups.id
+          WHERE groups.name IN (?)
+        )', allowed_groups)
+    else
+      real.where('users.admin OR users.moderator')
+    end
   end
 
   add_model_callback(Group, :before_update) do

--- a/spec/jobs/scheduled/enqueue_reminders_spec.rb
+++ b/spec/jobs/scheduled/enqueue_reminders_spec.rb
@@ -3,15 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe Jobs::EnqueueReminders do
-  let(:assign_allowed_group) { Group.find_by(name: 'staff') }
+  let(:assign_allowed_group) { Fabricate(:group) }
   let(:user) { Fabricate(:user, groups: [assign_allowed_group]) }
 
   before do
+    SiteSetting.assign_allowed_on_groups = assign_allowed_group.name
     SiteSetting.remind_assigns_frequency = RemindAssignsFrequencySiteSettings::MONTHLY_MINUTES
     SiteSetting.assign_enabled = true
   end
 
   describe '#execute' do
+    it 'enqueues a reminder when the user is an admin' do
+      SiteSetting.assign_allowed_on_groups = ''
+      admin = Fabricate(:admin)
+      assign_multiple_tasks_to(admin)
+
+      assert_reminders_enqueued(1)
+    end
+
     it 'does not enqueue reminders when there are no assigned tasks' do
       assert_reminders_enqueued(0)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User do
+  let(:group) { Fabricate(:group) }
+
+  before do
+    SiteSetting.assign_enabled = true
+    SiteSetting.assign_allowed_on_groups = group.name
+  end
+
+  describe '.assign_allowed' do
+    it 'retrieves the user when is a member of an allowed group' do
+      user = Fabricate(:user)
+      group.add(user)
+
+      expect(User.assign_allowed).to include(user)
+    end
+
+    it "doesn't retrieve the user when is not a member of an allowed group" do
+      non_assign_allowed_user = Fabricate(:user)
+
+      expect(User.assign_allowed).not_to include(non_assign_allowed_user)
+    end
+
+    it 'retrieves the user if is an admin' do
+      admin = Fabricate(:admin)
+
+      expect(User.assign_allowed).to include(admin)
+    end
+
+    it 'retrieves the user if is an moderator' do
+      moderator = Fabricate(:moderator)
+
+      expect(User.assign_allowed).to include(moderator)
+    end
+  end
+
+  describe '#can_assign?' do
+    it 'allows member of allowed groups to assign' do
+      user = Fabricate.build(:user)
+      group.add(user)
+
+      expect(user.can_assign?).to eq true
+    end
+
+    it "doesn't allow non allowed users to assign" do
+      user = Fabricate.build(:user)
+
+      expect(user.can_assign?).to eq false
+    end
+
+    it 'allows staff members to assign' do
+      admin = Fabricate.build(:admin)
+
+      expect(admin.can_assign?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
The first commit only brings the feature back. The second commit fixes a bug where the assign modal was not letting us search for users correctly.

cc @SamSaffron 