### PR TITLE
FIX: Skip enqueuing reminders if no groups are allowed.

### DIFF
--- a/jobs/scheduled/enqueue_reminders.rb
+++ b/jobs/scheduled/enqueue_reminders.rb
@@ -12,7 +12,7 @@ module Jobs
     private
 
     def skip_enqueue?
-      SiteSetting.remind_assigns_frequency.nil? || !SiteSetting.assign_enabled?
+      SiteSetting.remind_assigns_frequency.nil? || !SiteSetting.assign_enabled? || SiteSetting.assign_allowed_on_groups.blank?
     end
 
     def allowed_group_ids

--- a/spec/jobs/scheduled/enqueue_reminders_spec.rb
+++ b/spec/jobs/scheduled/enqueue_reminders_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Jobs::EnqueueReminders do
       assert_reminders_enqueued(0)
     end
 
-    it 'does not enqueue remidners when no groups are allowed to assign' do
+    it 'does not enqueue reminders when no groups are allowed to assign' do
       SiteSetting.assign_allowed_on_groups = ''
 
       assign_multiple_tasks_to(user)

--- a/spec/jobs/scheduled/enqueue_reminders_spec.rb
+++ b/spec/jobs/scheduled/enqueue_reminders_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Jobs::EnqueueReminders do
       assert_reminders_enqueued(0)
     end
 
+    it 'does not enqueue remidners when no groups are allowed to assign' do
+      SiteSetting.assign_allowed_on_groups = ''
+
+      assign_multiple_tasks_to(user)
+
+      assert_reminders_enqueued(0)
+    end
+
     it 'enqueues a reminder when the user has more than one task' do
       assign_multiple_tasks_to(user)
 


### PR DESCRIPTION
With an empty SiteSetting.assign_allowed_on_groups, it used to generate
an invalid query containing "group_users.group_id IN ()".