### PR TITLE
FEATURE: New rules for assigning a topic.

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -85,8 +85,11 @@ module DiscourseAssign
     private
 
     def translate_failure(reason, user)
-      if reason == :already_assigned
+      case reason
+      when :already_assigned
         { error: I18n.t('discourse_assign.already_assigned', username: user.username) }
+      when :forbidden_assign_to
+        { error: I18n.t('discourse_assign.forbidden_assign_to', username: user.username) }
       else
         max = SiteSetting.max_assigned_topics
         { error: I18n.t('discourse_assign.too_many_assigns', username: user.username, max: max) }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -22,6 +22,7 @@ en:
     already_claimed: "That topic has already been claimed."
     already_assigned: 'Topic is already assigned to @%{username}'
     too_many_assigns: "@%{username} has already reached the maximum number of assigned topics (%{max})."
+    forbidden_assign_to: "@%{username} can't be assigned since they don't have access to this topic."
     flag_assigned: "Sorry, that flag's topic is assigned to another user"
     flag_unclaimed: "You must claim that topic before acting on the flag"
     topic_assigned_excerpt: "assigned you the topic '%{title}'"

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/assign_allowed_group'
 
 describe 'integration tests' do
   before do
@@ -34,6 +35,13 @@ describe 'integration tests' do
     let(:user) { pm.allowed_users.first }
     let(:user2) { pm.allowed_users.last }
     let(:channel) { "/private-messages/assigned" }
+
+    include_context 'A group that is allowed to assign'
+
+    before do
+      add_to_assign_allowed_group(user)
+      add_to_assign_allowed_group(user2)
+    end
 
     def assert_publish_topic_state(topic, user)
       messages = MessageBus.track_publish do
@@ -92,6 +100,13 @@ describe 'integration tests' do
     let(:admin) { Fabricate(:admin) }
     let(:user1) { Fabricate(:user) }
     let(:user2) { Fabricate(:user) }
+
+    include_context 'A group that is allowed to assign'
+
+    before do
+      add_to_assign_allowed_group(user1)
+      add_to_assign_allowed_group(user2)
+    end
 
     it "assigns topic" do
       DiscourseEvent.trigger(:assign_topic, topic, user1, admin)

--- a/spec/lib/pending_assigns_reminder_spec.rb
+++ b/spec/lib/pending_assigns_reminder_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/assign_allowed_group'
 
 RSpec.describe PendingAssignsReminder do
   before { SiteSetting.assign_enabled = true }
@@ -25,7 +26,11 @@ RSpec.describe PendingAssignsReminder do
   describe 'when the user has multiple tasks' do
     let(:system) { Discourse.system_user }
 
+    include_context 'A group that is allowed to assign'
+
     before do
+      add_to_assign_allowed_group(user)
+
       @post1 = Fabricate(:post)
       @post2 = Fabricate(:post)
       @post3 = Fabricate(:post)

--- a/spec/serializers/topic_list_serializer_spec.rb
+++ b/spec/serializers/topic_list_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe TopicListSerializer do
-  let(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user) }
 
   let(:private_message_topic) do
     topic = Fabricate(:private_message_topic,
@@ -31,8 +31,11 @@ RSpec.describe TopicListSerializer do
   let(:guardian) { Guardian.new(user) }
   let(:serializer) { TopicListSerializer.new(topic_list, scope: guardian) }
 
+  include_context 'A group that is allowed to assign'
+
   before do
     SiteSetting.assign_enabled = true
+    add_to_assign_allowed_group(user)
   end
 
   describe '#assigned_messages_count' do

--- a/spec/support/assign_allowed_group.rb
+++ b/spec/support/assign_allowed_group.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+shared_context 'A group that is allowed to assign' do
+  fab!(:assign_allowed_group) { Fabricate(:group) }
+
+  before { SiteSetting.assign_allowed_on_groups += "|#{assign_allowed_group.id}" }
+
+  def add_to_assign_allowed_group(user)
+    assign_allowed_group.add(user)
+  end
+end


### PR DESCRIPTION
As discussed [here](https://meta.discourse.org/t/bug-possible-for-admin-to-assign-pm-to-moderator-who-does-not-have-access-to-the-pm/116571/6), it shouldn't be possible to assign a topic to a user when:

- The user won't be able to see the topic.
- The user is not a member of the assign allowed users.

This PR adds some backend rules to prevent these scenarios.