### PR TITLE
FIX: Suggest only groups that are visible to current user

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -24,7 +24,7 @@ module DiscourseAssign
         .limit(6)
 
       render json: {
-        assign_allowed_on_groups: Group.assign_allowed_groups.pluck(:name),
+        assign_allowed_on_groups: current_user.visible_groups.assign_allowed_groups.pluck(:name),
         suggestions: ActiveModel::ArraySerializer.new(users, scope: guardian, each_serializer: BasicUserSerializer)
       }
     end


### PR DESCRIPTION
Otherwise, the user would search in groups that were not visible,
operation which resulted in a 403 error.