### PR TITLE
FIX: do not escape `fancy_title` again.

### DIFF
--- a/assets/javascripts/discourse/widgets/quick-access-assignments.js.es6
+++ b/assets/javascripts/discourse/widgets/quick-access-assignments.js.es6
@@ -41,7 +41,7 @@ if (QuickAccessPanel) {
           assignedTopic.id,
           assignedTopic.last_read_post_number + 1
         ),
-        content: assignedTopic.fancy_title
+        escapedContent: assignedTopic.fancy_title
       });
     }
   });


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/quick-access-to-bookmarks-and-messages-on-user-menu/32787/50

This relies on the `escapedContent` attribute introduced in https://github.com/discourse/discourse/pull/8095.

<img width="300" alt="Screen Shot 2019-09-12 at 9 33 49 PM" src="https://user-images.githubusercontent.com/6376558/64837818-234bc880-d5a5-11e9-8a6c-f469c26c302e.png">

Thanks!