### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/jobs/regular/remind_user.rb
+++ b/jobs/regular/remind_user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class RemindUser < Jobs::Base
+  class RemindUser < ::Jobs::Base
     sidekiq_options queue: 'low'
 
     def execute(args)

--- a/jobs/scheduled/enqueue_reminders.rb
+++ b/jobs/scheduled/enqueue_reminders.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class EnqueueReminders < Jobs::Scheduled
+  class EnqueueReminders < ::Jobs::Scheduled
     every 1.day
 
     def execute(_args)


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364