### PR TITLE
UX: Update default path to users assigned topics

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ plugins:
   unassign_on_group_archive: false
   assigns_user_url_path:
     client: true
-    default: "/latest?assigned={username}"
+    default: "u/{username}/activity/assigned"
   assign_mailer_enabled: false
   remind_assigns_frequency:
     client: true


### PR DESCRIPTION
The old default path is not showing up all assigned topics if user has
muted categories or tags.