### PR TITLE
DEV: use site settings from container

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -133,8 +133,9 @@ function initialize(api) {
   api.modifyClass("model:topic", {
     @computed("assigned_to_user")
     assignedToUserPath(assignedToUser) {
+      const siteSettings = api.container.lookup("site-settings:main");
       return Discourse.getURL(
-        this.siteSettings.assigns_user_url_path.replace(
+        siteSettings.assigns_user_url_path.replace(
           "{username}",
           assignedToUser.username
         )


### PR DESCRIPTION
This is a bit more robust, site settings are not always injected (for example in raw handlebars templates).