### PR TITLE
FIX: Don't set assign button's height

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -81,10 +81,7 @@
   }
 }
 
-// we can't use flex for buttons yet
-// so this is an attempt to have a pixel perfection positioning
 #topic-footer-button-assign {
-  height: 30px;
   padding: 0 12px;
 
   .d-button-label {


### PR DESCRIPTION
"we can't use flex for buttons yet" – now we can, and we do! https://github.com/discourse/discourse/commit/e71f5e8951bcffdaac3476d96efaa2232b809a4c

Fixes an issue with assign button height in some themes.

Before/after:

<img width="587" alt="image" src="https://user-images.githubusercontent.com/66961/85951523-eb5f1780-b963-11ea-9403-7542c1c32f13.png">
<img width="582" alt="image" src="https://user-images.githubusercontent.com/66961/85952892-a8557200-b96c-11ea-988c-f5bc0c9058ef.png">

Core theme, no change:

<img width="380" alt="image" src="https://user-images.githubusercontent.com/66961/85952930-f79ba280-b96c-11ea-989b-b24d913b8fca.png">
<img width="402" alt="Screen Shot 2020-06-28 at 18 25 19" src="https://user-images.githubusercontent.com/66961/85952910-c8853100-b96c-11ea-8aa2-a7802a3663ee.png">
