### PR TITLE
UX: Improving styling so names/usernames fit better

### DIFF
--- a/assets/javascripts/discourse-assign/connectors/group-reports-nav-item/assigned-topic-list.hbs
+++ b/assets/javascripts/discourse-assign/connectors/group-reports-nav-item/assigned-topic-list.hbs
@@ -1,1 +1,1 @@
-{{group-assignments-menu-item group = group}}
+{{group-assignments-menu-item group = group tagName=""}}

--- a/assets/javascripts/discourse/components/group-assignments-filter.js.es6
+++ b/assets/javascripts/discourse/components/group-assignments-filter.js.es6
@@ -14,5 +14,21 @@ export default Component.extend({
       return username.trim();
     }
     return (name || username).trim();
+  },
+  @discourseComputed(
+    "siteSettings.prioritize_username_in_ux",
+    "filter.username",
+    "filter.name"
+  )
+  nameType(prioritize_username_in_ux, username, name) {
+    if (prioritize_username_in_ux) {
+      return "username";
+    } else {
+      if (name) {
+        return "full-name";
+      } else {
+        return "username";
+      }
+    }
   }
 });

--- a/assets/javascripts/discourse/templates/components/group-assignments-filter.hbs
+++ b/assets/javascripts/discourse/templates/components/group-assignments-filter.hbs
@@ -1,9 +1,12 @@
 {{#if show-avatar}}
   {{#link-to "group.assignments.show" filter.username_lower}}
-    {{avatar filter avatarTemplatePath="avatar_template" usernamePath="username" imageSize="small"}} {{displayName}} ({{filter.assignments_count}})
+    {{avatar filter avatarTemplatePath="avatar_template" usernamePath="username" imageSize="small"}}
+    <span class="assign-name {{nameType}}">{{displayName}}</span>
+    <span class="assign-count">({{filter.assignments_count}})</span>
   {{/link-to}}
 {{else}}
   {{#link-to "group.assignments.show" filter}}
-    {{i18n 'discourse_assign.group_everyone'}} ({{assignment_count}})
+    <span class="assign-name">{{i18n 'discourse_assign.group_everyone'}}</span>
+    <span class="assign-count">({{assignment_count}})</span>
   {{/link-to}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/group/assignments.hbs
+++ b/assets/javascripts/discourse/templates/group/assignments.hbs
@@ -1,4 +1,4 @@
-<section class="user-secondary-navigation">
+<section class="user-secondary-navigation group-assignments">
   {{#mobile-nav class="activity-nav" desktopClass="action-list activity-list nav-stacked" currentPath=router._router.currentPath}}
     {{#load-more selector=".activity-nav li" action=(action "loadMore")}}
       {{group-assignments-filter show-avatar=false filter="everyone" routeType=route_type assignment_count=group.assignment_count}}

--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -90,3 +90,41 @@
     }
   }
 }
+
+// Group assign nav sidebar
+
+.group-assignments {
+  // a little extra space for long names
+  min-width: 180px;
+  li {
+    width: 100%;
+    overflow: hidden;
+    a {
+      display: flex;
+      align-items: center;
+      img {
+        align-self: center;
+        margin-right: 0.25em;
+      }
+      .assign-name,
+      .assign-count {
+        padding-top: 0.15em;
+      }
+      .assign-name {
+        flex: 0 1 auto;
+        min-width: 0;
+        margin: 0 0.25em 0 0;
+        // Using both approaches because line-clamp works a little better for name + surname combos
+        &.full-name {
+          @include line-clamp(2);
+        }
+        &.username {
+          @include ellipsis;
+        }
+      }
+      .assign-count {
+        margin-left: auto;
+      }
+    }
+  }
+}

--- a/assets/stylesheets/mobile/assigns.scss
+++ b/assets/stylesheets/mobile/assigns.scss
@@ -24,3 +24,24 @@
     }
   }
 }
+
+.group-assignments .mobile-nav .drop li a {
+  display: flex;
+}
+
+.group-assignments .mobile-nav a.expander > span {
+  display: flex;
+  width: 90%;
+  img {
+    width: 1em;
+    height: 1em;
+  }
+  .assign-count {
+    display: none;
+  }
+  .assign-name {
+    display: block;
+    padding: 0;
+    @include ellipsis;
+  }
+}


### PR DESCRIPTION
Attempted to find a middle-ground that works for both long usernames without breaks and full names (which are more likely to have breaks)

<img width="186" alt="Screen Shot 2020-07-22 at 7 10 19 PM" src="https://user-images.githubusercontent.com/1681963/88238454-b63aa200-cc4f-11ea-9e60-469c3fe0128d.png">

