### PR TITLE
REFACTOR: Use core `default_results` function

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/group-assigned-show.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/group-assigned-show.js.es6
@@ -9,20 +9,20 @@ export default UserTopicsList.extend({
   taskActions: Ember.inject.service(),
   order: "",
   ascending: false,
-  q: "",
+  search: "",
   bulkSelectEnabled: false,
   selected: [],
   canBulkSelect: alias("currentUser.staff"),
 
-  queryParams: ["order", "ascending", "q"],
+  queryParams: ["order", "ascending", "search"],
 
-  @discourseComputed("q")
-  searchTerm(q) {
-    return q;
+  @discourseComputed("search")
+  searchTerm(search) {
+    return search;
   },
 
   _setSearchTerm(searchTerm) {
-    this.set("q", searchTerm);
+    this.set("search", searchTerm);
     this.refreshModel();
   },
 
@@ -34,7 +34,7 @@ export default UserTopicsList.extend({
         params: {
           order: this.order,
           ascending: this.ascending,
-          q: this.q,
+          search: this.search,
         },
       })
       .then((result) => this.set("model", result))

--- a/assets/javascripts/discourse-assign/controllers/group-assigned.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/group-assigned.js.es6
@@ -24,9 +24,9 @@ export default Controller.extend({
     return ascending || false;
   },
 
-  @discourseComputed("router.currentRoute.queryParams.q")
-  q(q) {
-    return q || "";
+  @discourseComputed("router.currentRoute.queryParams.search")
+  search(search) {
+    return search || "";
   },
 
   @discourseComputed("site.mobileView")

--- a/assets/javascripts/discourse-assign/controllers/user-activity-assigned.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/user-activity-assigned.js.es6
@@ -6,18 +6,18 @@ import { INPUT_DELAY } from "discourse-common/config/environment";
 export default UserTopicsList.extend({
   user: Ember.inject.controller(),
   taskActions: Ember.inject.service(),
-  queryParams: ["order", "ascending", "q"],
+  queryParams: ["order", "ascending", "search"],
   order: "",
   ascending: false,
-  q: "",
+  search: "",
 
-  @discourseComputed("q")
-  searchTerm(q) {
-    return q;
+  @discourseComputed("search")
+  searchTerm(search) {
+    return search;
   },
 
   _setSearchTerm(searchTerm) {
-    this.set("q", searchTerm);
+    this.set("search", searchTerm);
     this.refreshModel();
   },
 
@@ -29,7 +29,7 @@ export default UserTopicsList.extend({
         params: {
           order: this.order,
           ascending: this.ascending,
-          q: this.q,
+          search: this.search,
         },
       })
       .then((result) => this.set("model", result))

--- a/assets/javascripts/discourse-assign/routes/group-assigned-show.js.es6
+++ b/assets/javascripts/discourse-assign/routes/group-assigned-show.js.es6
@@ -28,7 +28,7 @@ export default DiscourseRoute.extend({
           params: {
             order: params.order,
             ascending: params.ascending,
-            q: params.q,
+            search: params.search,
           },
         });
   },
@@ -36,7 +36,7 @@ export default DiscourseRoute.extend({
   setupController(controller, model) {
     controller.setProperties({
       model,
-      searchTerm: this.currentModel.params.q,
+      searchTerm: this.currentModel.params.search,
     });
   },
 

--- a/assets/javascripts/discourse-assign/routes/user-activity-assigned.js.es6
+++ b/assets/javascripts/discourse-assign/routes/user-activity-assigned.js.es6
@@ -15,7 +15,7 @@ export default UserTopicListRoute.extend({
         exclude_category_ids: [-1],
         order: params.order,
         ascending: params.ascending,
-        q: params.q,
+        search: params.search,
       },
     });
   },

--- a/assets/javascripts/discourse/templates/components/group-assigned-filter.hbs
+++ b/assets/javascripts/discourse/templates/components/group-assigned-filter.hbs
@@ -1,5 +1,5 @@
 {{#if show-avatar}}
-  {{#link-to "group.assigned.show" filter.username_lower (query-params order=order ascending=ascending q=q)}}
+  {{#link-to "group.assigned.show" filter.username_lower (query-params order=order ascending=ascending search=search)}}
     <div class="assign-image">
       <a href={{filter.userPath}} data-user-card={{filter.username}}>{{avatar filter imageSize="large"}}</a>
     </div>
@@ -14,7 +14,7 @@
     </div>
   {{/link-to}}
 {{else}}
-  {{#link-to "group.assigned.show" filter (query-params order=order ascending=ascending q=q)}}
+  {{#link-to "group.assigned.show" filter (query-params order=order ascending=ascending search=search)}}
     <div class="assign-everyone">
       {{i18n "discourse_assign.group_everyone"}}
     </div>

--- a/assets/javascripts/discourse/templates/group/assigned.hbs
+++ b/assets/javascripts/discourse/templates/group/assigned.hbs
@@ -17,7 +17,7 @@
         filter="everyone"
         routeType=route_type
         assignmentCount=group.assignment_count
-        q=q
+        search=search
         ascending=ascending
         order=order}}
       {{#each members as |member|}}
@@ -25,7 +25,7 @@
           show-avatar=true
           filter=member
           routeType=route_type
-          q=q
+          search=search
           ascending=ascending
           order=order}}
       {{/each}}

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -228,13 +228,13 @@ describe ListController do
       topic2.save!
       topic3.save!
 
-      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { q: 'Testing' }
+      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { search: 'Testing' }
       expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to match_array([topic1.id, topic2.id, topic3.id])
 
-      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { q: 'RSpec' }
+      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { search: 'RSpec' }
       expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to match_array([topic2.id])
 
-      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { q: 'love' }
+      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { search: 'love' }
       expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to match_array([topic1.id])
     end
 
@@ -247,10 +247,10 @@ describe ListController do
       topic2.save!
       topic3.save!
 
-      get "/topics/messages-assigned/#{user.username}.json", params: { q: 'Testing' }
+      get "/topics/messages-assigned/#{user.username}.json", params: { search: 'Testing' }
       expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to match_array([topic1.id, topic3.id])
 
-      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { q: 'love' }
+      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json", params: { search: 'love' }
       expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to match_array([topic1.id])
     end
   end


### PR DESCRIPTION
This significantly reduces the amount of logic we need to carry in the discourse-assign plugin. One side effect is that I had to rename the 'q' parameter to 'search', so that it matches core's implementation.

Requires https://github.com/discourse/discourse/pull/10647 to be merged first