### PR TITLE
FIX: `onChange` needs an action

### DIFF
--- a/assets/javascripts/discourse/templates/components/remind-assigns-frequency.hbs
+++ b/assets/javascripts/discourse/templates/components/remind-assigns-frequency.hbs
@@ -5,7 +5,7 @@
       valueProperty="value"
       content=availableFrequencies
       value=selectedFrequency
-      onChange=(mut user.custom_fields.remind_assigns_frequency)
+      onChange=(action (mut user.custom_fields.remind_assigns_frequency))
     }}
   </div>
 {{/if}}


### PR DESCRIPTION
Before this fix it was impossible for a user to change their preference
for reminder frequency.