### PR TITLE
UX: adds margins to the assign tag in composer-popup

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -19,6 +19,10 @@
   .assign-text {
     margin-right: 0.25em;
   }
+
+  .composer-popup & {
+    margin-left: 0.5em;
+  }
 }
 
 .topic-body {


### PR DESCRIPTION
This PR adds some margins to the assign tags in the composer-popup.

Before 

<img src="https://user-images.githubusercontent.com/33972521/100543762-02948f00-328d-11eb-8147-3cc5d53eaf72.png" width=500>

After

<img src="https://user-images.githubusercontent.com/33972521/100543767-09230680-328d-11eb-98e5-278d96623b37.png" width=500>