### PR TITLE
DEV: Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/group-assigned-show.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/group-assigned-show.js.es6
@@ -1,7 +1,7 @@
 import UserTopicsList from "discourse/controllers/user-topics-list";
 import { alias } from "@ember/object/computed";
-import { debounce } from "@ember/runloop";
 import discourseComputed from "discourse-common/utils/decorators";
+import debounce from "discourse/plugins/discourse-assign/lib/debounce";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 
 export default UserTopicsList.extend({

--- a/assets/javascripts/discourse-assign/controllers/group-assigned.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/group-assigned.js.es6
@@ -1,9 +1,9 @@
 import { inject as service } from "@ember/service";
 import Controller, { inject as controller } from "@ember/controller";
 import { action } from "@ember/object";
-import { debounce } from "@ember/runloop";
 import { ajax } from "discourse/lib/ajax";
 import discourseComputed from "discourse-common/utils/decorators";
+import debounce from "discourse/plugins/discourse-assign/lib/debounce";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 
 export default Controller.extend({

--- a/assets/javascripts/discourse-assign/controllers/user-activity-assigned.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/user-activity-assigned.js.es6
@@ -1,6 +1,6 @@
 import UserTopicsList from "discourse/controllers/user-topics-list";
-import { debounce } from "@ember/runloop";
 import discourseComputed from "discourse-common/utils/decorators";
+import debounce from "discourse/plugins/discourse-assign/lib/debounce";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 
 export default UserTopicsList.extend({

--- a/assets/javascripts/lib/debounce.js.es6
+++ b/assets/javascripts/lib/debounce.js.es6
@@ -1,0 +1,6 @@
+import discourseDebounce from "discourse-common/lib/debounce";
+import { debounce } from "@ember/runloop";
+
+// TODO: Remove this file and use discouseDebounce after the 2.7 release.
+const debounceFunction = discourseDebounce || debounce;
+export default debounceFunction;


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.