### PR TITLE
Adjust button padding to account for avatar

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -86,6 +86,8 @@
 }
 
 #topic-footer-button-assign {
+  padding-top: 0.35em;
+  padding-bottom: 0.35em;
   .d-button-label {
     .avatar {
       margin-right: 0.25em;


### PR DESCRIPTION
Follow up to f7bb92b

I could have completely removed the vertical padding like it was previously, but reducing it works similarly and also prevents the button from collapsing completely if it wraps to its own line.