### PR TITLE
 FIX: Use Ember's debounce on stable.

### DIFF
--- a/assets/javascripts/lib/debounce.js.es6
+++ b/assets/javascripts/lib/debounce.js.es6
@@ -1,6 +1,10 @@
-import discourseDebounce from "discourse-common/lib/debounce";
 import { debounce } from "@ember/runloop";
 
 // TODO: Remove this file and use discouseDebounce after the 2.7 release.
-const debounceFunction = discourseDebounce || debounce;
+let debounceFunction = debounce;
+
+try {
+  debounceFunction = require("discourse-common/lib/debounce").default;
+} catch (_) {}
+
 export default debounceFunction;


### PR DESCRIPTION
We need to wrap the new debounce function inside a try block to avoid throwing a "module not found" exception.