### PR TITLE
FIX: Add autofocus to users chooser on the assign modal

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
@@ -1,6 +1,7 @@
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { inject as controller } from "@ember/controller";
+import discourseComputed from "discourse-common/utils/decorators";
 
 export default Ember.Controller.extend({
   topicBulkActions: controller(),
@@ -16,6 +17,11 @@ export default Ember.Controller.extend({
       this.set("assignSuggestions", data.suggestions);
       this.set("allowedGroups", data.assign_allowed_on_groups);
     });
+  },
+
+  @discourseComputed("capabilities.touch")
+  autofocus(touch) {
+    return !touch;
   },
 
   onClose() {

--- a/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
@@ -1,13 +1,14 @@
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { inject as controller } from "@ember/controller";
-import discourseComputed from "discourse-common/utils/decorators";
+import { not } from "@ember/object/computed";
 
 export default Ember.Controller.extend({
   topicBulkActions: controller(),
   assignSuggestions: null,
   allowedGroups: null,
   taskActions: Ember.inject.service(),
+  autofocus: not("capabilities.touch"),
 
   init() {
     this._super(...arguments);
@@ -17,11 +18,6 @@ export default Ember.Controller.extend({
       this.set("assignSuggestions", data.suggestions);
       this.set("allowedGroups", data.assign_allowed_on_groups);
     });
-  },
-
-  @discourseComputed("capabilities.touch")
-  autofocus(touch) {
-    return !touch;
   },
 
   onClose() {

--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -11,6 +11,7 @@
         includeGroups=false
         groupMembersOf=allowedGroups
         maximum=1
+        autofocus=autofocus
       )
     }}
     <div class="assign-suggestions">


### PR DESCRIPTION
The users chooser on the assign modal is the primary input field on the modal, so it makes to shift focus to it when the modal is opened. This PR needs https://github.com/discourse/discourse/commit/0f807ba85b869fffc9560d97632d3ca7471e7fc4 in core to work properly, but it won't cause errors (won't have any effects) if it's deployed to a site that doesn't have that commit.