### PR TITLE
updated assign_allowed_on_groups admin setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,7 +13,7 @@ en:
     remind_assigns: "Remind users about pending assigns."
     remind_assigns_frequency: "Frequency for reminding users about assigned topics."
     max_assigned_topics: "Maximum number of topics that can be assigned to a user."
-    assign_allowed_on_groups: "Groups that are allowed to assign topics."
+    assign_allowed_on_groups: "Users in these groups are allowed to assign topics and can be assigned topics."
   discourse_assign:
     assigned_to: "Topic assigned to @%{username}"
     unassigned: "Topic was unassigned"


### PR DESCRIPTION
I had a bit of trouble finding how to enable this feature for a user so I could assign topics to the user. This is the setting, so I updated it to explain that it allows assigning to users as well as allows the user to assign topics to others.