### PR TITLE
FIX: Assign topic button not working

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
@@ -79,6 +79,7 @@ export default Controller.extend({
       .catch(popupAjaxError);
   },
 
+  @action
   updateUsername(selected) {
     this.set("model.username", selected.firstObject);
   },

--- a/test/javascripts/acceptance/assign-enabled-test.js.es6
+++ b/test/javascripts/acceptance/assign-enabled-test.js.es6
@@ -11,13 +11,76 @@ acceptance("Assign mobile", function (needs) {
   needs.settings({ assign_enabled: true });
   needs.hooks.beforeEach(() => clearTopicFooterButtons());
 
+  needs.pretender((server, helper) => {
+    server.get("/assign/suggestions", () => {
+      return helper.response({
+        success: true,
+        assign_allowed_groups: false,
+        suggestions: [
+          {
+            id: 19,
+            username: "eviltrout",
+            name: "Robin Ward",
+            avatar_template:
+              "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
+          },
+        ],
+      });
+    });
+
+    server.put("/assign/assign", () => {
+      return helper.response({ success: true });
+    });
+  });
+
   test("Footer dropdown contains button", async (assert) => {
     updateCurrentUser({ can_assign: true });
-    const menu = selectKit(".topic-footer-mobile-dropdown");
-
     await visit("/t/internationalization-localization/280");
+    const menu = selectKit(".topic-footer-mobile-dropdown");
     await menu.expand();
 
     assert.ok(menu.rowByValue("assign").exists());
+    await menu.selectRowByValue("assign");
+    assert.ok(exists(".assign.modal-body"), "assign modal opens");
+
+    await click(".assign-suggestions .avatar");
+  });
+});
+
+acceptance("Assign desktop", function (needs) {
+  needs.user();
+  needs.settings({ assign_enabled: true });
+  needs.hooks.beforeEach(() => clearTopicFooterButtons());
+
+  needs.pretender((server, helper) => {
+    server.get("/assign/suggestions", () => {
+      return helper.response({
+        success: true,
+        assign_allowed_groups: false,
+        suggestions: [
+          {
+            id: 19,
+            username: "eviltrout",
+            name: "Robin Ward",
+            avatar_template:
+              "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
+          },
+        ],
+      });
+    });
+
+    server.put("/assign/assign", () => {
+      return helper.response({ success: true });
+    });
+  });
+
+  test("Footer dropdown contains button", async (assert) => {
+    updateCurrentUser({ can_assign: true });
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-button-assign");
+
+    assert.ok(exists(".assign.modal-body"), "assign modal opens");
+
+    await click(".assign-suggestions .avatar");
   });
 });


### PR DESCRIPTION
Since this commit
https://github.com/discourse/discourse-assign/commit/195dcc92cb3bab9dd7b7457efb7beca06959baae
the updateUsername function was missing an @action decorator. This adds
it back and extends the assign acceptance tests to click the
mobile/desktop assign buttons and open the modal and click the
suggestion to save the assignment.