### PR TITLE
DEV: add a prefix with the plugin name to spec names

### DIFF
--- a/test/javascripts/acceptance/assign-enabled-test.js.es6
+++ b/test/javascripts/acceptance/assign-enabled-test.js.es6
@@ -8,7 +8,7 @@ import { click, visit } from "@ember/test-helpers";
 import { clearTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
 import { test } from "qunit";
 
-acceptance("Assign mobile", function (needs) {
+acceptance("Discourse Assign | Assign mobile", function (needs) {
   needs.user();
   needs.mobileView();
   needs.settings({ assign_enabled: true });
@@ -50,7 +50,7 @@ acceptance("Assign mobile", function (needs) {
   });
 });
 
-acceptance("Assign desktop", function (needs) {
+acceptance("Discourse Assign | Assign desktop", function (needs) {
   needs.user();
   needs.settings({ assign_enabled: true });
   needs.hooks.beforeEach(() => clearTopicFooterButtons());

--- a/test/javascripts/acceptance/assigned-topic-test.js.es6
+++ b/test/javascripts/acceptance/assigned-topic-test.js.es6
@@ -9,7 +9,7 @@ import { visit } from "@ember/test-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
 
-acceptance("Assigned topic", function (needs) {
+acceptance("Discourse Assign | Assigned topic", function (needs) {
   needs.user();
   needs.settings({
     assign_enabled: true,

--- a/test/javascripts/acceptance/group-assignments-test.js.es6
+++ b/test/javascripts/acceptance/group-assignments-test.js.es6
@@ -4,7 +4,7 @@ import AssignedTopics from "../fixtures/assigned-group-assignments-fixtures";
 import GroupMembers from "../fixtures/group-members-fixtures";
 import { test } from "qunit";
 
-acceptance("GroupAssignments", function (needs) {
+acceptance("Discourse Assign | GroupAssignments", function (needs) {
   needs.user();
   needs.settings({ assign_enabled: true, assigns_user_url_path: "/" });
   needs.pretender((server, helper) => {

--- a/test/javascripts/acceptance/quick-access-assignments-test.js.es6
+++ b/test/javascripts/acceptance/quick-access-assignments-test.js.es6
@@ -7,7 +7,7 @@ import { click, currentURL, visit } from "@ember/test-helpers";
 import AssignedTopics from "../fixtures/assigned-topics-fixtures";
 import { test } from "qunit";
 
-acceptance("Quick access assignments panel", function (needs) {
+acceptance("Discourse Assign | Quick access assignments panel", function (needs) {
   needs.user();
   needs.settings({ assign_enabled: true, assigns_user_url_path: "/" });
 

--- a/test/javascripts/acceptance/search-full-test.js.es6
+++ b/test/javascripts/acceptance/search-full-test.js.es6
@@ -7,7 +7,7 @@ import {
 import { fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
-acceptance("Search - Full Page", function (needs) {
+acceptance("Discourse Assign | Search - Full Page", function (needs) {
   needs.settings({ assign_enabled: true });
   needs.user();
   needs.pretender((server, helper) => {

--- a/test/javascripts/acceptance/un-assign-from-list-test.js.es6
+++ b/test/javascripts/acceptance/un-assign-from-list-test.js.es6
@@ -4,7 +4,7 @@ import { visit } from "@ember/test-helpers";
 import AssignedTopics from "../fixtures/assigned-topics-fixtures";
 import { test } from "qunit";
 
-acceptance("UnAssign/Re-assign from the topics list", function (needs) {
+acceptance("Discourse Assign | UnAssign/Re-assign from the topics list", function (needs) {
   needs.user();
   needs.settings({ assign_enabled: true, assigns_user_url_path: "/" });
   needs.pretender((server, helper) => {

--- a/test/javascripts/components/group-assigned-filter-test.js.es6
+++ b/test/javascripts/components/group-assigned-filter-test.js.es6
@@ -5,7 +5,7 @@ import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
 import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
-  "Integration | Component | group-assigned-filter",
+  "Discourse Assign | Integration | Component | group-assigned-filter",
   function (hooks) {
     setupRenderingTest(hooks);
 


### PR DESCRIPTION
I had discourse-assign installed on my local Discourse instance and one spec that has the same name as another spec in Core was causing the error when running qunit tests locally, the whole suite didn't want to run:

<img width="680" alt="Screenshot 2021-07-30 at 20 12 57" src="https://user-images.githubusercontent.com/1274517/127696094-14fc614b-6556-4dc3-9139-5a882b20592a.png">

I've added a prefix to that spec (https://github.com/discourse/discourse-assign/commit/3aeeea3c8af13e5ee9c0fee6f5ae7b2c5c371241) and to the rest of them to avoid conflicts and make it easier to filter specs for the plugin during local development.