### PR TITLE
FIX: unassign/assign when group pm is archived

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -538,7 +538,7 @@ after_initialize do
   # TopicTrackingState
   add_class_method(:topic_tracking_state, :publish_assigned_private_message) do |topic, assignee|
     return unless topic.private_message?
-    opts = 
+    opts =
       if assignee.is_a?(User)
         { user_ids: [assignee.id] }
       else
@@ -587,6 +587,10 @@ after_initialize do
       assigner = TopicAssigner.new(topic, Discourse.system_user)
       assigner.assign(previous_assigned_to, silent: true)
     end
+
+    topic.custom_fields.delete("prev_assigned_to_id")
+    topic.custom_fields.delete("prev_assigned_to_type")
+    topic.save!
   end
 
   on(:archive_message) do |info|

--- a/plugin.rb
+++ b/plugin.rb
@@ -538,19 +538,18 @@ after_initialize do
   # TopicTrackingState
   add_class_method(:topic_tracking_state, :publish_assigned_private_message) do |topic, assignee|
     return unless topic.private_message?
-    if assignee.is_a?(User)
-      MessageBus.publish(
-        "/private-messages/assigned",
-        { topic_id: topic.id },
-        user_ids: [assignee.id]
-      )
-    else
-      MessageBus.publish(
-        "/private-messages/assigned",
-        { topic_id: topic.id },
-        group_ids: [assignee.id]
-      )
-    end
+    opts = 
+      if assignee.is_a?(User)
+        { user_ids: [assignee.id] }
+      else
+        { group_ids: [assignee.id] }
+      end
+
+    MessageBus.publish(
+      "/private-messages/assigned",
+      { topic_id: topic.id },
+      opts
+    )
   end
 
   # Event listeners

--- a/plugin.rb
+++ b/plugin.rb
@@ -67,6 +67,7 @@ after_initialize do
   register_editable_user_custom_field frequency_field
   User.register_custom_field_type frequency_field, :integer
   Topic.register_custom_field_type "prev_assigned_to_id", :integer
+  Topic.register_custom_field_type "prev_assigned_to_type", :string
   DiscoursePluginRegistry.serialized_current_user_fields << frequency_field
   add_to_serializer(:user, :reminders_frequency) do
     RemindAssignsFrequencySiteSettings.values

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -84,6 +84,8 @@ describe 'integration tests' do
 
       GroupArchivedMessage.move_to_inbox!(group.id, pm.reload)
       expect(pm.assignment.assigned_to).to eq(user)
+      expect(pm.custom_fields["prev_assigned_to_id"]).to eq(nil)
+      expect(pm.custom_fields["prev_assigned_to_type"]).to eq(nil)
     end
 
     it "unassign and assign group if unassign_on_group_archive" do

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -34,7 +34,7 @@ describe 'integration tests' do
       group.add(user2)
     end
 
-    def assert_publish_topic_state(topic, user)
+    def assert_publish_topic_state(topic, user: nil, group: nil)
       messages = MessageBus.track_publish do
         yield
       end
@@ -42,18 +42,19 @@ describe 'integration tests' do
       message = messages.find { |m| m.channel == channel }
 
       expect(message.data[:topic_id]).to eq(topic.id)
-      expect(message.user_ids).to eq([user.id])
+      expect(message.user_ids).to eq([user.id]) if user
+      expect(message.group_ids).to eq([group.id]) if group
     end
 
     it 'publishes the right message on archive and move to inbox' do
       assigner = TopicAssigner.new(pm, user)
       assigner.assign(user)
 
-      assert_publish_topic_state(pm, user) do
+      assert_publish_topic_state(pm, user: user) do
         UserArchivedMessage.archive!(user.id, pm.reload)
       end
 
-      assert_publish_topic_state(pm, user) do
+      assert_publish_topic_state(pm, user: user) do
         UserArchivedMessage.move_to_inbox!(user.id, pm.reload)
       end
     end
@@ -62,11 +63,11 @@ describe 'integration tests' do
       assigner = TopicAssigner.new(pm, user)
       assigner.assign(group)
 
-      assert_publish_topic_state(pm, user) do
+      assert_publish_topic_state(pm, group: group) do
         GroupArchivedMessage.archive!(group.id, pm.reload)
       end
 
-      assert_publish_topic_state(pm, user) do
+      assert_publish_topic_state(pm, group: group) do
         GroupArchivedMessage.move_to_inbox!(group.id, pm.reload)
       end
     end
@@ -78,7 +79,7 @@ describe 'integration tests' do
 
       GroupArchivedMessage.archive!(group.id, pm.reload)
       expect(pm.assignment).to eq(nil)
-      expect(pm.custom_fields["prev_assigned_to_id"]).to eq(user.id.to_s)
+      expect(pm.custom_fields["prev_assigned_to_id"]).to eq(user.id)
       expect(pm.custom_fields["prev_assigned_to_type"]).to eq("User")
 
       GroupArchivedMessage.move_to_inbox!(group.id, pm.reload)
@@ -92,7 +93,7 @@ describe 'integration tests' do
 
       GroupArchivedMessage.archive!(group.id, pm.reload)
       expect(pm.assignment).to eq(nil)
-      expect(pm.custom_fields["prev_assigned_to_id"]).to eq(group.id.to_s)
+      expect(pm.custom_fields["prev_assigned_to_id"]).to eq(group.id)
       expect(pm.custom_fields["prev_assigned_to_type"]).to eq("Group")
 
       GroupArchivedMessage.move_to_inbox!(group.id, pm.reload)

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -23,7 +23,7 @@ describe 'integration tests' do
     let(:user) { pm.allowed_users.first }
     let(:user2) { pm.allowed_users.last }
     let(:channel) { "/private-messages/assigned" }
-    fab!(:group) { Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]) }
+    fab!(:group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:everyone]) }
 
     include_context 'A group that is allowed to assign'
 


### PR DESCRIPTION
Send correct messages and correctly unassign/assign to user/group if group PM is archived or moved back to inbox.