### PR TITLE
FEATURE: new assignable group option instead of messageable

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -25,7 +25,7 @@ module DiscourseAssign
 
       render json: {
         assign_allowed_on_groups: Group.visible_groups(current_user).assign_allowed_groups.pluck(:name),
-        assign_allowed_for_groups: Group.visible_groups(current_user).messageable(current_user).pluck(:name),
+        assign_allowed_for_groups: Group.visible_groups(current_user).assignable(current_user).pluck(:name),
         suggestions: ActiveModel::ArraySerializer.new(users, scope: guardian, each_serializer: BasicUserSerializer),
       }
     end

--- a/assets/javascripts/discourse-assign/connectors/groups-interaction-custom-options/assignable-interaction-fields.hbs
+++ b/assets/javascripts/discourse-assign/connectors/groups-interaction-custom-options/assignable-interaction-fields.hbs
@@ -1,0 +1,13 @@
+<div class="control-group">
+  <label class="control-label">{{i18n "discourse_assign.admin.groups.manage.interaction.assign"}}</label>
+  <label for="visiblity">{{i18n "discourse_assign.admin.groups.manage.interaction.assignable_levels.title"}}</label>
+
+  {{combo-box
+    name="alias"
+    valueProperty="value"
+    value=assignableLevel
+    content=assignableLevelOptions
+    class="groups-form-assignable-level"
+    onChange=(action (mut model.assignable_level))
+  }}
+</div>

--- a/assets/javascripts/discourse-assign/connectors/groups-interaction-custom-options/assignable-interaction-fields.js.es6
+++ b/assets/javascripts/discourse-assign/connectors/groups-interaction-custom-options/assignable-interaction-fields.js.es6
@@ -1,0 +1,24 @@
+import I18n from "I18n";
+import { or } from "@ember/object/computed";
+import { defineProperty } from "@ember/object";
+
+export default {
+  name: "assignable-interaction-fields",
+
+  setupComponent(args, component) {
+    this.assignableLevelOptions = [
+      { name: I18n.t("groups.alias_levels.nobody"), value: 0 },
+      { name: I18n.t("groups.alias_levels.only_admins"), value: 1 },
+      { name: I18n.t("groups.alias_levels.mods_and_admins"), value: 2 },
+      { name: I18n.t("groups.alias_levels.members_mods_and_admins"), value: 3 },
+      { name: I18n.t("groups.alias_levels.owners_mods_and_admins"), value: 4 },
+      { name: I18n.t("groups.alias_levels.everyone"), value: 99 },
+    ];
+
+    defineProperty(
+      component,
+      "assignableLevel",
+      or("model.assignable_level", "assignableLevelOptions.firstObject.value")
+    );
+  },
+};

--- a/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
@@ -10,7 +10,6 @@ export default Controller.extend({
   topicBulkActions: controller(),
   assignSuggestions: null,
   allowedGroups: null,
-  customGroupsScope: "assignable",
   taskActions: service(),
   autofocus: not("capabilities.touch"),
   assigneeName: or("model.username", "model.group_name"),

--- a/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js.es6
@@ -10,6 +10,7 @@ export default Controller.extend({
   topicBulkActions: controller(),
   assignSuggestions: null,
   allowedGroups: null,
+  customGroupsScope: "assignable",
   taskActions: service(),
   autofocus: not("capabilities.touch"),
   assigneeName: or("model.username", "model.group_name"),

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -450,5 +450,8 @@ export default {
       api.addGroupPostSmallActionCode("assigned_group");
       api.addGroupPostSmallActionCode("unassigned_group");
     });
+    withPluginApi("0.12.3", (api) => {
+      api.addUserSearchOption("assignableGroups");
+    });
   },
 };

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -273,6 +273,14 @@ function initialize(api) {
     },
   });
 
+  api.modifyClass("model:group", {
+    asJSON() {
+      return Object.assign({}, this._super(...arguments), {
+        assignable_level: this.assignable_level,
+      });
+    },
+  });
+
   api.modifyClass("controller:topic", {
     pluginId: PLUGIN_ID,
 

--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -9,8 +9,8 @@
       options=(hash
         placementStrategy="absolute"
         filterPlaceholder=placeholderKey
-        includeGroups=false
-        includeMessageableGroups=true
+        includeGroups=true
+        customGroupsScope=customGroupsScope
         groupMembersOf=allowedGroups
         maximum=1
         autofocus=autofocus

--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -10,7 +10,7 @@
         placementStrategy="absolute"
         filterPlaceholder=placeholderKey
         includeGroups=true
-        customGroupsScope=customGroupsScope
+        assignableGroups=true
         groupMembersOf=allowedGroups
         maximum=1
         autofocus=autofocus

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -47,6 +47,13 @@ en:
         weekly: "Weekly"
         monthly: "Monthly"
         quarterly: "Quarterly"
+      admin:
+        groups:
+          manage:
+            interaction:
+              assign: "Assign"
+              assignable_levels:
+                title: "Who can assign this group"
     user:
       messages:
         assigned_title: "Assigned (%{count})"

--- a/db/migrate/20210830024453_add_assignable_level_to_groups.rb
+++ b/db/migrate/20210830024453_add_assignable_level_to_groups.rb
@@ -2,6 +2,6 @@
 
 class AddAssignableLevelToGroups < ActiveRecord::Migration[6.1]
   def change
-    add_column :groups, :assignable_level, :integer, default: 0
+    add_column :groups, :assignable_level, :integer, default: 0, null: false
   end
 end

--- a/db/migrate/20210830024453_add_assignable_level_to_groups.rb
+++ b/db/migrate/20210830024453_add_assignable_level_to_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAssignableLevelToGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :assignable_level, :integer, default: 0
+  end
+end

--- a/lib/topic_assigner.rb
+++ b/lib/topic_assigner.rb
@@ -126,7 +126,7 @@ class ::TopicAssigner
   end
 
   def allowed_group_ids
-    @allowed_group_ids ||= Group.messageable(@assigned_by).pluck(:id)
+    @allowed_group_ids ||= Group.assignable(@assigned_by).pluck(:id)
   end
 
   def can_assign_to?(assign_to)

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,8 +36,24 @@ after_initialize do
   require 'topic_assigner'
   require 'pending_assigns_reminder'
 
+  register_group_param(:assignable_level)
+  register_group_scope_for_search(:assignable)
+
   class ::Topic
     has_one :assignment, dependent: :destroy
+  end
+
+  class ::Group
+    scope :assignable, ->(user) {
+      where("assignable_level in (:levels) OR
+          (
+            assignable_level = #{ALIAS_LEVELS[:members_mods_and_admins]} AND id in (
+            SELECT group_id FROM group_users WHERE user_id = :user_id)
+          ) OR (
+            assignable_level = #{ALIAS_LEVELS[:owners_mods_and_admins]} AND id in (
+            SELECT group_id FROM group_users WHERE user_id = :user_id AND owner IS TRUE)
+          )", levels: alias_levels(user), user_id: user && user.id)
+    }
   end
 
   frequency_field = PendingAssignsReminder::REMINDERS_FREQUENCY
@@ -71,6 +87,10 @@ after_initialize do
 
   add_to_serializer(:group_show, 'include_assignment_count?') do
     scope.can_assign?
+  end
+
+  add_to_serializer(:group_show, :assignable_level) do
+    object.assignable_level
   end
 
   add_to_serializer(:group_show, :can_show_assigned_tab?) do

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,8 +36,13 @@ after_initialize do
   require 'topic_assigner'
   require 'pending_assigns_reminder'
 
-  register_group_param(:assignable_level)
-  register_group_scope_for_search(:assignable)
+  # TODO: Drop when Discourse stable 2.8.0 is released
+  if respond_to?(:register_group_param)
+    register_group_param(:assignable_level)
+  end
+  if respond_to?(:register_group_scope_for_search)
+    register_group_scope_for_search(:assignable)
+  end
 
   class ::Topic
     has_one :assignment, dependent: :destroy

--- a/plugin.rb
+++ b/plugin.rb
@@ -40,8 +40,10 @@ after_initialize do
   if respond_to?(:register_group_param)
     register_group_param(:assignable_level)
   end
-  if respond_to?(:register_group_scope_for_search)
-    register_group_scope_for_search(:assignable)
+  if respond_to?(:register_groups_callback_for_users_search_controller_action)
+    register_groups_callback_for_users_search_controller_action(:assignable_groups) do |groups, user|
+      groups.assignable(user)
+    end
   end
 
   class ::Topic

--- a/spec/serializers/group_show_serializer_spec.rb
+++ b/spec/serializers/group_show_serializer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe GroupShowSerializer do
   fab!(:user) { Fabricate(:user) }
-  fab!(:group) { Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]) }
+  fab!(:group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:everyone]) }
   fab!(:group_user) { Fabricate(:group_user, group: group, user: user) }
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/spec/support/assign_allowed_group.rb
+++ b/spec/support/assign_allowed_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_context 'A group that is allowed to assign' do
-  fab!(:assign_allowed_group) { Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]) }
+  fab!(:assign_allowed_group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:everyone]) }
 
   before do
     SiteSetting.assign_allowed_on_groups += "|#{assign_allowed_group.id}"


### PR DESCRIPTION
V1 of group assign was using "who can message" to determine if group can be assigned.

This PR is introducing new separate setting "who can assign"

Correlated PR https://github.com/discourse/discourse/pull/14216 (Specs will fail until core pr is merged)

<img width="301" alt="Screen Shot 2021-09-02 at 11 06 03 am" src="https://user-images.githubusercontent.com/72780/131765249-ae5b3c11-0928-4f5e-b969-7c53580e5c7d.png">
