### PR TITLE
FEATURE: advance search groups

### DIFF
--- a/assets/javascripts/discourse-assign/connectors/advanced-search-options-below/assigned-advanced-search.hbs
+++ b/assets/javascripts/discourse-assign/connectors/advanced-search-options-below/assigned-advanced-search.hbs
@@ -1,12 +1,14 @@
 <div class="control-group pull-left">
   <label class="control-label" for="search-assigned-to">{{i18n "search.advanced.assigned.label"}}</label>
   <div class="controls">
-    {{user-chooser
+    {{email-group-user-chooser
       value=searchedTerms.assigned
       onChange=(action "onChangeAssigned")
       options=(hash
         maximum=1
         excludeCurrentUser=false
+        includeGroups=true
+        assignableGroups=true
       )
     }}
   </div>


### PR DESCRIPTION
Allow advance search filter to select topics assigned to specific group

<img width="366" alt="Screen Shot 2021-09-08 at 11 29 46 am" src="https://user-images.githubusercontent.com/72780/132431594-ea43e6e2-b082-4566-bd24-f03ba6719d76.png">
