### PR TITLE
FIX: add assigned fields to suggested topic serializer

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -4,4 +4,12 @@ class Assignment < ActiveRecord::Base
   belongs_to :topic
   belongs_to :assigned_to, polymorphic: true
   belongs_to :assigned_by_user, class_name: "User"
+
+  def assigned_to_user?
+    assigned_to_type == 'User'
+  end
+
+  def assigned_to_group?
+    assigned_to_type == 'Group'
+  end
 end

--- a/app/serializers/assigned_topic_serializer.rb
+++ b/app/serializers/assigned_topic_serializer.rb
@@ -17,7 +17,7 @@ class AssignedTopicSerializer < BasicTopicSerializer
   end
 
   def include_assigned_to_user?
-    object.assigned_to.is_a?(User)
+    object.assignment.assigned_to_user?
   end
 
   def assigned_to_group
@@ -25,6 +25,6 @@ class AssignedTopicSerializer < BasicTopicSerializer
   end
 
   def include_assigned_to_group?
-    object.assigned_to.is_a?(Group)
+    object.assignment.assigned_to_group?
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -423,6 +423,23 @@ after_initialize do
     (SiteSetting.assigns_public || scope.can_assign?) && object.topic.assigned_to&.is_a?(Group)
   end
 
+  # SuggestedTopic serializer
+  add_to_serializer(:suggested_topic, :assigned_to_user, false) do
+    DiscourseAssign::Helpers.build_assigned_to_user(object.assigned_to, object)
+  end
+
+  add_to_serializer(:suggested_topic, :include_assigned_to_user?) do
+    (SiteSetting.assigns_public || scope.can_assign?) && object.assigned_to&.is_a?(User)
+  end
+
+  add_to_serializer(:suggested_topic, :assigned_to_group, false) do
+    DiscourseAssign::Helpers.build_assigned_to_group(object.assigned_to, object)
+  end
+
+  add_to_serializer(:suggested_topic, :include_assigned_to_group?) do
+    (SiteSetting.assigns_public || scope.can_assign?) && object.assigned_to&.is_a?(Group)
+  end
+
   # TopicListItem serializer
   add_to_serializer(:topic_list_item, :assigned_to_user) do
     BasicUserSerializer.new(object.assigned_to, scope: scope, root: false).as_json

--- a/spec/serializers/suggested_topic_serializer_spec.rb
+++ b/spec/serializers/suggested_topic_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SuggestedTopicSerializer do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:everyone]) }
+  fab!(:group_user) { Fabricate(:group_user, group: group, user: user) }
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:topic2) { Fabricate(:topic) }
+  fab!(:post2) { Fabricate(:post, topic: topic2) }
+  fab!(:guardian) { Guardian.new(user) }
+  fab!(:serializer) { described_class.new(topic, scope: guardian) }
+  fab!(:serializer2) { described_class.new(topic2, scope: guardian) }
+
+  before do
+    SiteSetting.assign_enabled = true
+    SiteSetting.assign_allowed_on_groups = group.id.to_s
+  end
+
+  it "adds information about assignee for users and groups" do
+    TopicAssigner.new(topic, user).assign(user)
+    expect(serializer.as_json[:suggested_topic][:assigned_to_user][:username]).to eq(user.username)
+
+    TopicAssigner.new(topic2, user).assign(group)
+    expect(serializer2.as_json[:suggested_topic][:assigned_to_group][:name]).to eq(group.name)
+  end
+end


### PR DESCRIPTION
With hard refresh, information about assigned user disappeared from suggested topics.