### PR TITLE
FIX: Allow Never selection for frequency of assigned topic reminders

### DIFF
--- a/assets/javascripts/discourse/components/remind-assigns-frequency.js.es6
+++ b/assets/javascripts/discourse/components/remind-assigns-frequency.js.es6
@@ -1,13 +1,23 @@
 import Component from "@ember/component";
 import I18n from "I18n";
-import { or } from "@ember/object/computed";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
-  selectedFrequency: or(
+  @discourseComputed(
     "user.custom_fields.remind_assigns_frequency",
     "siteSettings.remind_assigns_frequency"
-  ),
+  )
+  selectedFrequency(userAssignsFrequency, siteDefaultAssignsFrequency) {
+    if (
+      this.availableFrequencies
+        .map((freq) => freq.value)
+        .includes(userAssignsFrequency)
+    ) {
+      return userAssignsFrequency;
+    }
+
+    return siteDefaultAssignsFrequency;
+  },
 
   @discourseComputed("user.reminders_frequency")
   availableFrequencies(userRemindersFrequency) {

--- a/assets/javascripts/discourse/templates/components/remind-assigns-frequency.hbs
+++ b/assets/javascripts/discourse/templates/components/remind-assigns-frequency.hbs
@@ -2,6 +2,7 @@
   <div class="controls controls-dropdown">
     <label>{{i18n "discourse_assign.reminders_frequency.description"}}</label>
     {{combo-box
+      id="remind-assigns-frequency"
       valueProperty="value"
       content=availableFrequencies
       value=selectedFrequency


### PR DESCRIPTION
If the user selected Never for their frequency of assigned topic
reminder PMs, the option automatically set back to the default
value (Monthly) because of the user of the `or` computed helper,
which considered the 0 value of Never to be falsey.

This is the same problem that occurred in core which was fixed by
https://github.com/discourse/discourse/commit/d3779d4cf75bd9c21cf61e016047a92fe66d3fdd

We need to be careful around using the `or` helper if any of the
options could be considered falsey.