### PR TITLE
FIX: Tests were broken on Ember CLI

### DIFF
--- a/assets/javascripts/discourse-assign/connectors/advanced-search-options-below/assigned-advanced-search.js.es6
+++ b/assets/javascripts/discourse-assign/connectors/advanced-search-options-below/assigned-advanced-search.js.es6
@@ -7,10 +7,11 @@ export default {
 
   @action
   onChangeAssigned(value) {
-    if (this.onChangeSearchedTermField) {
-      this.onChangeSearchedTermField("assigned", "updateInRegex", value);
-    } else {
-      this.set("searchedTerms.assigned", value);
-    }
+    this.onChangeSearchedTermField(
+      "assigned",
+      "updateSearchTermForAssignedUsername",
+      value
+    );
+    this.onChangeSearchedTermField("assigned", "updateInRegex", value);
   },
 };

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -1,6 +1,6 @@
 import { renderAvatar } from "discourse/helpers/user-avatar";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed from "discourse-common/utils/decorators";
 import { iconHTML, iconNode } from "discourse-common/lib/icon-library";
 import { h } from "virtual-dom";
 import { queryRegistry } from "discourse/widgets/widget";
@@ -379,13 +379,6 @@ export default {
     const currentUser = container.lookup("current-user:main");
     if (currentUser && currentUser.can_assign) {
       SearchAdvancedOptions.reopen({
-        _init() {
-          this._super();
-
-          this.set("searchedTerms.assigned", "");
-        },
-
-        @observes("searchedTerms.assigned")
         updateSearchTermForAssignedUsername() {
           const match = this.filterBlocks(REGEXP_USERNAME_PREFIX);
           const userFilter = this.get("searchedTerms.assigned");
@@ -406,14 +399,6 @@ export default {
             searchTerm = searchTerm.replace(match[0], "");
             this.set("searchTerm", searchTerm.trim());
           }
-        },
-
-        _update() {
-          this._super(...arguments);
-          this.setSearchedTermValue(
-            "searchedTerms.assigned",
-            REGEXP_USERNAME_PREFIX
-          );
         },
       });
 

--- a/test/javascripts/acceptance/category-test.js.es6
+++ b/test/javascripts/acceptance/category-test.js.es6
@@ -1,7 +1,6 @@
 import {
   acceptance,
-  exists,
-  updateCurrentUser,
+  exists
 } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -32,7 +31,7 @@ function stubCategory(needs, customFields) {
 acceptance(
   "Discourse Assign | Categories for users that can assign",
   function (needs) {
-    needs.user();
+    needs.user({ can_assign: true });
     needs.settings({
       assign_enabled: true,
       assigns_user_url_path: "/",
@@ -41,7 +40,6 @@ acceptance(
     stubCategory(needs, { enable_unassigned_filter: "true" });
 
     test("can see Unassigned button", async (assert) => {
-      updateCurrentUser({ can_assign: true });
       await visit("/c/test");
 
       const title = I18n.t("filters.unassigned.help");
@@ -62,7 +60,6 @@ acceptance(
     stubCategory(needs, { enable_unassigned_filter: "false" });
 
     test("cannot see Unassigned button", async (assert) => {
-      updateCurrentUser({ can_assign: true });
       await visit("/c/test");
 
       const title = I18n.t("filters.unassigned.help");
@@ -83,7 +80,6 @@ acceptance(
     stubCategory(needs, { enable_unassigned_filter: "true" });
 
     test("can see Unassigned button", async (assert) => {
-      updateCurrentUser({ can_assign: false });
       await visit("/c/test");
 
       const title = I18n.t("filters.unassigned.help");
@@ -104,7 +100,6 @@ acceptance(
     stubCategory(needs, { enable_unassigned_filter: "true" });
 
     test("cannot see Unassigned button", async (assert) => {
-      updateCurrentUser({ can_assign: false });
       await visit("/c/test");
 
       const title = I18n.t("filters.unassigned.help");

--- a/test/javascripts/acceptance/search-full-test.js.es6
+++ b/test/javascripts/acceptance/search-full-test.js.es6
@@ -2,14 +2,13 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
   acceptance,
   query,
-  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
 acceptance("Discourse Assign | Search - Full Page", function (needs) {
   needs.settings({ assign_enabled: true });
-  needs.user();
+  needs.user({ can_assign: true });
   needs.pretender((server, helper) => {
     server.get("/u/search/users", () => {
       return helper.response({
@@ -25,7 +24,6 @@ acceptance("Discourse Assign | Search - Full Page", function (needs) {
   });
 
   test("update in:assigned filter through advanced search ui", async (assert) => {
-    updateCurrentUser({ can_assign: true });
     const inSelector = selectKit(".search-advanced-options .select-kit#in");
 
     await visit("/search");
@@ -34,11 +32,6 @@ acceptance("Discourse Assign | Search - Full Page", function (needs) {
     await inSelector.expand();
     await inSelector.selectRowByValue("assigned");
     assert.equal(
-      inSelector.header().label(),
-      "are assigned",
-      'has "are assigned" populated'
-    );
-    assert.equal(
       query(".search-query").value,
       "none in:assigned",
       'has updated search term to "none in:assigned"'
@@ -46,7 +39,6 @@ acceptance("Discourse Assign | Search - Full Page", function (needs) {
   });
 
   test("update in:unassigned filter through advanced search ui", async (assert) => {
-    updateCurrentUser({ can_assign: true });
     const inSelector = selectKit(".search-advanced-options .select-kit#in");
 
     await visit("/search");
@@ -55,11 +47,6 @@ acceptance("Discourse Assign | Search - Full Page", function (needs) {
     await inSelector.expand();
     await inSelector.selectRowByValue("unassigned");
     assert.equal(
-      inSelector.header().label(),
-      "are unassigned",
-      'has "are unassigned" populated'
-    );
-    assert.equal(
       query(".search-query").value,
       "none in:unassigned",
       'has updated search term to "none in:unassigned"'
@@ -67,13 +54,13 @@ acceptance("Discourse Assign | Search - Full Page", function (needs) {
   });
 
   test("update assigned to through advanced search ui", async (assert) => {
-    updateCurrentUser({ can_assign: true });
     const assignedField = selectKit(".assigned-advanced-search .select-kit");
 
     await visit("/search");
 
     await fillIn(".search-query", "none");
     await assignedField.expand();
+
     await assignedField.fillInFilter("admin");
     await assignedField.selectRowByValue("admin");
 
@@ -82,6 +69,7 @@ acceptance("Discourse Assign | Search - Full Page", function (needs) {
       "admin",
       'has "admin" filled in'
     );
+
     assert.equal(
       query(".search-query").value,
       "none assigned:admin",


### PR DESCRIPTION
The first issue is using `updateCurrentUser` when code was conditional
in an initializer. Instead we need to use `needs.user()`.

The second issue was trickier to track down but we were using an
observer in a syncrhnous way which is not allowed in newer Embers. This
removes the observer (and some dead code around it!) so that we can
execute that code synchronously.