### PR TITLE
DEV: Fix dev plugin reloading issue

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -46,21 +46,23 @@ after_initialize do
     end
   end
 
-  class ::Topic
-    has_one :assignment, dependent: :destroy
-  end
+  reloadable_patch do |plugin|
+    class ::Topic
+      has_one :assignment, dependent: :destroy
+    end
 
-  class ::Group
-    scope :assignable, ->(user) {
-      where("assignable_level in (:levels) OR
-          (
-            assignable_level = #{ALIAS_LEVELS[:members_mods_and_admins]} AND id in (
-            SELECT group_id FROM group_users WHERE user_id = :user_id)
-          ) OR (
-            assignable_level = #{ALIAS_LEVELS[:owners_mods_and_admins]} AND id in (
-            SELECT group_id FROM group_users WHERE user_id = :user_id AND owner IS TRUE)
-          )", levels: alias_levels(user), user_id: user && user.id)
-    }
+    class ::Group
+      scope :assignable, ->(user) {
+        where("assignable_level in (:levels) OR
+            (
+              assignable_level = #{ALIAS_LEVELS[:members_mods_and_admins]} AND id in (
+              SELECT group_id FROM group_users WHERE user_id = :user_id)
+            ) OR (
+              assignable_level = #{ALIAS_LEVELS[:owners_mods_and_admins]} AND id in (
+              SELECT group_id FROM group_users WHERE user_id = :user_id AND owner IS TRUE)
+            )", levels: alias_levels(user), user_id: user && user.id)
+      }
+    end
   end
 
   frequency_field = PendingAssignsReminder::REMINDERS_FREQUENCY


### PR DESCRIPTION
On dev environment, when editing a local file, I would often see this error: 

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/368961/134542131-40a759ef-74e0-4cf5-9630-a74c444caf59.png">

@davidtaylorhq pointed out that this is due to these monkey-patches not being reloadable by Zeitwerk. This doesn't fix the problem for all of the monkey patches, but this Topic one is probably the most common. 