### PR TITLE
FIX: n+1 query on list of private messages assigned

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -294,7 +294,7 @@ after_initialize do
 
     sql = "topics.id IN (#{topic_ids_sql})"
 
-    list = list.where(sql, user_id: user.id)
+    list = list.where(sql, user_id: user.id).includes(:allowed_users)
 
     create_list(:assigned, { unordered: true }, list)
   end
@@ -319,7 +319,7 @@ after_initialize do
 
     sql = "topics.id IN (#{topic_ids_sql})"
 
-    list = list.where(sql, group_id: group.id)
+    list = list.where(sql, group_id: group.id).includes(:allowed_users)
 
     create_list(:assigned, { unordered: true }, list)
   end


### PR DESCRIPTION
When getting a list of private messages assigned to groups/users, we should include :allowed_users to avoid n+1

<img width="1049" alt="Screen Shot 2021-09-29 at 8 54 47 am" src="https://user-images.githubusercontent.com/72780/135176958-13ac23e7-beda-46c8-9637-399a55c37417.png">
