### PR TITLE
FIX: assignment table migration when SKIP_POST_DEPLOYMENT_MIGRATIONS

### DIFF
--- a/db/post_migrate/20210714173022_correctly_move_assignments_from_custom_fields_to_a_table.rb
+++ b/db/post_migrate/20210714173022_correctly_move_assignments_from_custom_fields_to_a_table.rb
@@ -12,21 +12,40 @@ class CorrectlyMoveAssignmentsFromCustomFieldsToATable < ActiveRecord::Migration
         AND topic_custom_fields.name = 'assigned_to_id'
     SQL
 
-    execute <<~SQL
-      INSERT INTO assignments (assigned_to_id, assigned_by_user_id, topic_id, created_at, updated_at)
-      SELECT
-        assigned_to.value::integer,
-        assigned_by.value::integer,
-        assigned_by.topic_id,
-        assigned_by.created_at,
-        assigned_by.updated_at
-      FROM topic_custom_fields assigned_by
-      INNER JOIN topic_custom_fields assigned_to ON assigned_to.topic_id = assigned_by.topic_id
-      WHERE assigned_by.name = 'assigned_by_id'
-        AND assigned_to.name = 'assigned_to_id'
-      ORDER BY assigned_by.created_at DESC
-      ON CONFLICT DO NOTHING
-    SQL
+    if column_exists?(:assignments, :assigned_to_type)
+      execute <<~SQL
+        INSERT INTO assignments (assigned_to_id, assigned_by_user_id, topic_id, created_at, updated_at, assigned_to_type)
+        SELECT
+          assigned_to.value::integer,
+          assigned_by.value::integer,
+          assigned_by.topic_id,
+          assigned_by.created_at,
+          assigned_by.updated_at,
+          'User'
+        FROM topic_custom_fields assigned_by
+        INNER JOIN topic_custom_fields assigned_to ON assigned_to.topic_id = assigned_by.topic_id
+        WHERE assigned_by.name = 'assigned_by_id'
+          AND assigned_to.name = 'assigned_to_id'
+        ORDER BY assigned_by.created_at DESC
+        ON CONFLICT DO NOTHING
+      SQL
+    else
+      execute <<~SQL
+        INSERT INTO assignments (assigned_to_id, assigned_by_user_id, topic_id, created_at, updated_at)
+        SELECT
+          assigned_to.value::integer,
+          assigned_by.value::integer,
+          assigned_by.topic_id,
+          assigned_by.created_at,
+          assigned_by.updated_at
+        FROM topic_custom_fields assigned_by
+        INNER JOIN topic_custom_fields assigned_to ON assigned_to.topic_id = assigned_by.topic_id
+        WHERE assigned_by.name = 'assigned_by_id'
+          AND assigned_to.name = 'assigned_to_id'
+        ORDER BY assigned_by.created_at DESC
+        ON CONFLICT DO NOTHING
+      SQL
+    end
   end
 
   def down


### PR DESCRIPTION
We need two branches of that migration. One when `assigned_to_type` is missing and another when `assigned_to_type` exists.

https://meta.discourse.org/t/db-migration-version-20210714173022-fails-when-having-skipped-post-deployment-migrations-before/204660