### PR TITLE
UX: Remove an obsolete css class from an element

### DIFF
--- a/assets/javascripts/discourse-assign/connectors/advanced-search-options-below/assigned-advanced-search.hbs
+++ b/assets/javascripts/discourse-assign/connectors/advanced-search-options-below/assigned-advanced-search.hbs
@@ -1,4 +1,4 @@
-<div class="control-group pull-left">
+<div class="control-group">
   <label class="control-label" for="search-assigned-to">{{i18n "search.advanced.assigned.label"}}</label>
   <div class="controls">
     {{email-group-user-chooser


### PR DESCRIPTION
1. It's not needed in the new advanced search interface
2. It causes problems in some cases