### PR TITLE
FEATURE: display indirect assignments in the first post

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -23,6 +23,9 @@
   .composer-popup & {
     margin-left: 0.5em;
   }
+  .assignee:not(:last-child):after {
+    content: ", ";
+  }
 }
 
 .topic-body {

--- a/plugin.rb
+++ b/plugin.rb
@@ -413,7 +413,7 @@ after_initialize do
   add_to_class(:topic, :indirectly_assigned_to) do
     return @indirectly_assigned_to if defined?(@indirectly_assigned_to)
     @indirectly_assigned_to = Assignment.where(topic_id: id, target_type: "Post").inject({}) do |acc, assignment|
-      acc[assignment.target_id] = assignment.assigned_to
+      acc[assignment.target.post_number] = assignment.assigned_to
       acc
     end
   end

--- a/test/javascripts/acceptance/assigned-topic-test.js.es6
+++ b/test/javascripts/acceptance/assigned-topic-test.js.es6
@@ -26,6 +26,11 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
         avatar_template:
           "/letter_avatar/eviltrout/{size}/3_f9720745f5ce6dfc2b5641fca999d934.png",
       };
+      topic["indirectly_assigned_to"] = {
+        2: {
+          name: "Developers",
+        },
+      };
       return helper.response(topic);
     });
 
@@ -48,9 +53,9 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "shows assignment in the header"
     );
     assert.equal(
-      query("#post_1 .assigned-to-username").innerText.trim(),
-      "eviltrout",
-      "shows assignment in the first post"
+      query("#post_1 .assigned-to").innerText,
+      "Assigned toeviltrout#2 Developers",
+      "shows assignment and indirect assignments in the first post"
     );
     assert.ok(exists("#post_1 .assigned-to svg.d-icon-user-plus"));
     assert.ok(
@@ -69,7 +74,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "shows assignment in the header"
     );
     assert.equal(
-      query("#post_1 .assigned-to-username").innerText.trim(),
+      query("#post_1 .assigned-to-group").innerText.trim(),
       "Developers",
       "shows assignment in the first post"
     );


### PR DESCRIPTION
A link in the first post will allow going to a specific post assigned to a user or group.

<img width="488" alt="Screen Shot 2021-11-02 at 2 55 35 pm" src="https://user-images.githubusercontent.com/72780/139785274-597a6bb3-3242-4d48-81dc-3a113d93632e.png">
