### PR TITLE
FIX: move post assignment when move post

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -737,6 +737,16 @@ after_initialize do
     end
   end
 
+  on(:post_moved) do |post, original_topic_id|
+    assignment = Assignment.where(topic_id: original_topic_id, target_type: "Post", target_id: post.id).first
+    return if !assignment
+    if post.is_first_post?
+      assignment.update!(topic_id: post.topic_id, target_type: "Topic", target_id: post.topic_id)
+    else
+      assignment.update!(topic_id: post.topic_id)
+    end
+  end
+
   class ::WebHook
     def self.enqueue_assign_hooks(event, payload)
       if active_web_hooks('assign').exists?

--- a/plugin.rb
+++ b/plugin.rb
@@ -739,7 +739,7 @@ after_initialize do
 
   on(:post_moved) do |post, original_topic_id|
     assignment = Assignment.where(topic_id: original_topic_id, target_type: "Post", target_id: post.id).first
-    return if !assignment
+    next if !assignment
     if post.is_first_post?
       assignment.update!(topic_id: post.topic_id, target_type: "Topic", target_id: post.topic_id)
     else


### PR DESCRIPTION
When an assigned post is moved to the new topic, it becomes topic assignment.

When an assigned post is moved to an existing topic it stays post assignment