### PR TITLE
FIX: rename action_code_href to action_code_path

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,12 +7,12 @@ en:
     action_codes:
       assigned: "assigned %{who} %{when}"
       assigned_group: "assigned %{who} %{when}"
-      assigned_to_post: "assigned %{who} to <a href='%{href}' data-auto-route='true'>post</a> %{when}"
-      assigned_group_to_post: "assigned %{who} to <a href='%{href}' data-auto-route='true'>post</a> %{when}"
+      assigned_to_post: "assigned %{who} to <a href='%{path}' data-auto-route='true'>post</a> %{when}"
+      assigned_group_to_post: "assigned %{who} to <a href='%{path}' data-auto-route='true'>post</a> %{when}"
       unassigned: "unassigned %{who} %{when}"
       unassigned_group: "unassigned %{who} %{when}"
-      unassigned_from_post: "unassigned %{who} from <a href='%{href}' data-auto-route='true'>post</a> %{when}"
-      unassigned_group_from_post: "unassigned %{who} from <a href='%{href}' data-auto-route='true'>post</a> %{when}"
+      unassigned_from_post: "unassigned %{who} from <a href='%{path}' data-auto-route='true'>post</a> %{when}"
+      unassigned_group_from_post: "unassigned %{who} from <a href='%{path}' data-auto-route='true'>post</a> %{when}"
     discourse_assign:
       add_unassigned_filter: "Add 'unassigned' filter to category"
       cant_act: "You cannot act on flags that have been assigned to other users"

--- a/db/post_migrate/20211108023921_change_action_code_href_to_action_code_path.rb
+++ b/db/post_migrate/20211108023921_change_action_code_href_to_action_code_path.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ChangeActionCodeHrefToActionCodePath < ActiveRecord::Migration[6.1]
+  def up
+    DB.exec(<<~SQL)
+      UPDATE post_custom_fields
+      SET name = 'action_code_path'
+      WHERE name = 'action_code_href'
+    SQL
+  end
+
+  def down
+    DB.exec(<<~SQL)
+      UPDATE post_custom_fields
+      SET name = 'action_code_href'
+      WHERE name = 'action_code_path'
+    SQL
+  end
+end

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -253,7 +253,7 @@ class ::Assigner
       custom_fields = { "action_code_who" => assign_to.is_a?(User) ? assign_to.username : assign_to.name }
 
       if post_target?
-        custom_fields.merge!("action_code_href" => "/p/#{@target.id}")
+        custom_fields.merge!("action_code_path" => "/p/#{@target.id}")
       end
 
       topic.add_moderator_post(
@@ -333,7 +333,7 @@ class ::Assigner
         custom_fields = { "action_code_who" => assigned_to.is_a?(User) ? assigned_to.username : assigned_to.name }
 
         if post_target?
-          custom_fields.merge!("action_code_href" => "/p/#{@target.id}")
+          custom_fields.merge!("action_code_path" => "/p/#{@target.id}")
         end
 
         topic.add_moderator_post(


### PR DESCRIPTION
We should use relative paths, therefore name change is necessary to avoid confusions. Post migration is added to fix existing data.

Related PR: https://github.com/discourse/discourse/pull/14834