### PR TITLE
FIX: no error when assigned post is deleted

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -425,7 +425,7 @@ after_initialize do
   add_to_class(:topic, :indirectly_assigned_to) do
     return @indirectly_assigned_to if defined?(@indirectly_assigned_to)
     @indirectly_assigned_to = Assignment.where(topic_id: id, target_type: "Post").inject({}) do |acc, assignment|
-      acc[assignment.target.post_number] = assignment.assigned_to
+      acc[assignment.target.post_number] = assignment.assigned_to if assignment.target
       acc
     end
   end


### PR DESCRIPTION
When an assigned post is deleted, we should not error. For now, assignment object is left untouched to not lose information when post is `undeleted`.

We can change that behaviour later if we decide that assignments should be deleted as well.