### PR TITLE
Show custom topic tracking message when the user 'never' automatically tracks topics and gets assigned

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -511,25 +511,13 @@ function initialize(api) {
       "topic",
       "topic.details.{notification_level,notifications_reason_id}"
     )
-    notificationReasonText(topic, topicDetails) {
-      if (this.currentUser.auto_track_topics_after_msecs === -1) {
-        if (
-          topic.assigned_to_user &&
-          topic.assigned_to_user.username === this.currentUser.username
-        ) {
-          return I18n.t("notification_reason.user");
-        }
-        if (
-          topic.assigned_to_group &&
-          this.currentUser.groups &&
-          this.currentUser.groups.some(
-            ({ id }) => id === topic.assigned_to_group.id
-          )
-        ) {
-          return I18n.t("notification_reason.group", {
-            name: topic.assigned_to_group.name,
-          });
-        }
+    notificationReasonText(topic) {
+      if (
+        this.currentUser.auto_track_topics_after_msecs === -1 &&
+        topic.assigned_to_user &&
+        topic.assigned_to_user.username === this.currentUser.username
+      ) {
+        return I18n.t("notification_reason.user");
       }
 
       return this._super(...arguments);

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -507,6 +507,8 @@ function initialize(api) {
   });
 
   api.modifyClass("component:topic-notifications-button", {
+    pluginId: PLUGIN_ID,
+
     @discourseComputed(
       "topic",
       "topic.details.{notification_level,notifications_reason_id}"

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -515,7 +515,7 @@ function initialize(api) {
     )
     notificationReasonText(topic) {
       if (
-        this.currentUser.auto_track_topics_after_msecs === -1 &&
+        this.currentUser.never_auto_track_topics &&
         topic.assigned_to_user &&
         topic.assigned_to_user.username === this.currentUser.username
       ) {

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -506,6 +506,36 @@ function initialize(api) {
     },
   });
 
+  api.modifyClass("component:topic-notifications-button", {
+    @discourseComputed(
+      "topic",
+      "topic.details.{notification_level,notifications_reason_id}"
+    )
+    notificationReasonText(topic, topicDetails) {
+      if (this.currentUser.auto_track_topics_after_msecs === -1) {
+        if (
+          topic.assigned_to_user &&
+          topic.assigned_to_user.username === this.currentUser.username
+        ) {
+          return I18n.t("notification_reason.user");
+        }
+        if (
+          topic.assigned_to_group &&
+          this.currentUser.groups &&
+          this.currentUser.groups.some(
+            ({ id }) => id === topic.assigned_to_group.id
+          )
+        ) {
+          return I18n.t("notification_reason.group", {
+            name: topic.assigned_to_group.name,
+          });
+        }
+      }
+
+      return this._super(...arguments);
+    },
+  });
+
   api.addPostSmallActionIcon("assigned", "user-plus");
   api.addPostSmallActionIcon("assigned_to_post", "user-plus");
   api.addPostSmallActionIcon("assigned_group", "group-plus");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -121,4 +121,3 @@ en:
               label: Users in working hours
     notification_reason:
       user: "You will see a count of new replies because this topic was assigned to you."
-      group: "You will see a count of new replies because this topic was assigned to your group @%{name}."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -119,3 +119,6 @@ en:
               label: Assigned Topic ID
             in_working_hours:
               label: Users in working hours
+    notification_reason:
+      user: "You will see a count of new replies because this topic was assigned to you."
+      group: "You will see a count of new replies because this topic was assigned to your group @%{name}."

--- a/lib/discourse_assign/helpers.rb
+++ b/lib/discourse_assign/helpers.rb
@@ -17,6 +17,7 @@ module DiscourseAssign
       return if !group
 
       {
+        id: group.id,
         name: group.name,
         flair_bg_color: group.flair_bg_color,
         flair_color: group.flair_color,

--- a/lib/discourse_assign/helpers.rb
+++ b/lib/discourse_assign/helpers.rb
@@ -17,7 +17,6 @@ module DiscourseAssign
       return if !group
 
       {
-        id: group.id,
         name: group.name,
         flair_bg_color: group.flair_bg_color,
         flair_color: group.flair_color,

--- a/plugin.rb
+++ b/plugin.rb
@@ -133,6 +133,10 @@ after_initialize do
     @can_assign == :true
   end
 
+  add_to_serializer(:current_user, :auto_track_topics_after_msecs) do
+    user.user_option.auto_track_topics_after_msecs
+  end
+
   add_to_class(:group, :can_show_assigned_tab?) do
     allowed_group_ids = SiteSetting.assign_allowed_on_groups.split("|")
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -133,8 +133,8 @@ after_initialize do
     @can_assign == :true
   end
 
-  add_to_serializer(:current_user, :auto_track_topics_after_msecs) do
-    user.user_option.auto_track_topics_after_msecs
+  add_to_serializer(:current_user, :never_auto_track_topics) do
+    user.user_option.auto_track_topics_after_msecs < 0
   end
 
   add_to_class(:group, :can_show_assigned_tab?) do

--- a/test/javascripts/acceptance/never-track-assign-reason-test.js.es6
+++ b/test/javascripts/acceptance/never-track-assign-reason-test.js.es6
@@ -44,7 +44,7 @@ acceptance(
     });
 
     test("Show default assign reason when user tracks topics", async (assert) => {
-      updateCurrentUser({ auto_track_topics_after_msecs: 1 });
+      updateCurrentUser({ never_auto_track_topics: false });
 
       await visit("/t/assignment-topic/44");
 
@@ -56,7 +56,7 @@ acceptance(
 
     test("Show user assign reason when user never tracks topics", async (assert) => {
       updateCurrentUser({
-        auto_track_topics_after_msecs: -1,
+        never_auto_track_topics: true,
       });
 
       await visit("/t/assignment-topic/45");

--- a/test/javascripts/acceptance/never-track-assign-reason-test.js.es6
+++ b/test/javascripts/acceptance/never-track-assign-reason-test.js.es6
@@ -1,0 +1,88 @@
+import { test } from "qunit";
+import {
+  acceptance,
+  query,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { visit } from "@ember/test-helpers";
+import { cloneJSON } from "discourse-common/lib/object";
+import topicFixtures from "discourse/tests/fixtures/topic";
+
+acceptance(
+  "Discourse Assign | Never track topics assign reason",
+  function (needs) {
+    needs.user();
+    needs.settings({
+      assign_enabled: true,
+      assigns_user_url_path: "/",
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/t/44.json", () => {
+        let topic = cloneJSON(topicFixtures["/t/130.json"]);
+        topic.details.notifications_reason_id = 3;
+        return helper.response(topic);
+      });
+      server.get("/t/45.json", () => {
+        let topic = cloneJSON(topicFixtures["/t/28830/1.json"]);
+        topic["assigned_to_user"] = {
+          username: "eviltrout",
+          name: "Robin Ward",
+          avatar_template:
+            "/letter_avatar/eviltrout/{size}/3_f9720745f5ce6dfc2b5641fca999d934.png",
+        };
+        return helper.response(topic);
+      });
+      server.get("/t/46.json", () => {
+        let topic = cloneJSON(topicFixtures["/t/28830/1.json"]);
+        topic["assigned_to_group"] = {
+          id: 47,
+          name: "discourse",
+        };
+        return helper.response(topic);
+      });
+    });
+
+    test("Show default assign reason when user tracks topics", async (assert) => {
+      updateCurrentUser({ auto_track_topics_after_msecs: 1 });
+
+      await visit("/t/assignment-topic/44");
+
+      assert.strictEqual(
+        query(".topic-notifications-button .reason span.text").innerText,
+        "You will receive notifications because you are watching this topic."
+      );
+    });
+
+    test("Show user assign reason when user never tracks topics", async (assert) => {
+      updateCurrentUser({
+        auto_track_topics_after_msecs: -1,
+      });
+
+      await visit("/t/assignment-topic/45");
+
+      assert.strictEqual(
+        query(".topic-notifications-button .reason span.text").innerText,
+        "You will see a count of new replies because this topic was assigned to you."
+      );
+    });
+
+    test("Show group assign reason when user never tracks topics", async (assert) => {
+      updateCurrentUser({
+        auto_track_topics_after_msecs: -1,
+        groups: [
+          {
+            id: 47,
+          },
+        ],
+      });
+
+      await visit("/t/assignment-topic/46");
+
+      assert.strictEqual(
+        query(".topic-notifications-button .reason span.text").innerText,
+        "You will see a count of new replies because this topic was assigned to your group @discourse."
+      );
+    });
+  }
+);

--- a/test/javascripts/acceptance/never-track-assign-reason-test.js.es6
+++ b/test/javascripts/acceptance/never-track-assign-reason-test.js.es6
@@ -66,23 +66,5 @@ acceptance(
         "You will see a count of new replies because this topic was assigned to you."
       );
     });
-
-    test("Show group assign reason when user never tracks topics", async (assert) => {
-      updateCurrentUser({
-        auto_track_topics_after_msecs: -1,
-        groups: [
-          {
-            id: 47,
-          },
-        ],
-      });
-
-      await visit("/t/assignment-topic/46");
-
-      assert.strictEqual(
-        query(".topic-notifications-button .reason span.text").innerText,
-        "You will see a count of new replies because this topic was assigned to your group @discourse."
-      );
-    });
   }
 );


### PR DESCRIPTION
When the user "never" tracks topics, 
<img width="809" alt="Screenshot 2021-11-17 at 3 08 59 PM" src="https://user-images.githubusercontent.com/1555215/142151027-d13dca45-6513-4a8a-8903-65ff1e238c92.png">

We want to show a more accurate tracking message when he gets assigned to a topic
<img width="779" alt="Screenshot 2021-11-17 at 3 10 09 PM" src="https://user-images.githubusercontent.com/1555215/142151031-d7eb6cfa-646e-4834-ac5f-dfa82a838c25.png">