### PR TITLE
FIX: Update aria-labels on mobile / dropdown

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -129,7 +129,12 @@ function registerTopicFooterButtons(api) {
       const content = [
         {
           id: "unassign",
-          name: htmlSafe(
+          name: I18n.t("discourse_assign.unassign.help", {
+            username:
+              this.topic.assigned_to_user?.username ||
+              this.topic.assigned_to_group?.name,
+          }),
+          label: htmlSafe(
             `${iconHTML("user-times")} ${I18n.t(
               "discourse_assign.unassign.title"
             )}`
@@ -143,7 +148,8 @@ function registerTopicFooterButtons(api) {
       ) {
         content.push({
           id: "reassign-self",
-          name: htmlSafe(
+          name: I18n.t("discourse_assign.reassign.to_self_help"),
+          label: htmlSafe(
             `${iconHTML("user-plus")} ${I18n.t(
               "discourse_assign.reassign.to_self"
             )}`
@@ -152,7 +158,8 @@ function registerTopicFooterButtons(api) {
       }
       content.push({
         id: "reassign",
-        name: htmlSafe(
+        name: I18n.t("discourse_assign.reassign.help"),
+        label: htmlSafe(
           `${iconHTML("group-plus")} ${I18n.t(
             "discourse_assign.reassign.title_w_ellipsis"
           )}`
@@ -311,10 +318,10 @@ function registerTopicFooterButtons(api) {
       return "user-plus";
     },
     translatedTitle() {
-      return defaultTitle(this);
+      return I18n.t("discourse_assign.reassign.to_self_help");
     },
     translatedAriaLabel() {
-      return defaultTitle(this);
+      return I18n.t("discourse_assign.reassign.to_self_help");
     },
     translatedLabel() {
       const label = I18n.t("discourse_assign.reassign.to_self");
@@ -361,10 +368,10 @@ function registerTopicFooterButtons(api) {
       return "group-plus";
     },
     translatedTitle() {
-      return defaultTitle(this);
+      return I18n.t("discourse_assign.reassign.help");
     },
     translatedAriaLabel() {
-      return defaultTitle(this);
+      return I18n.t("discourse_assign.reassign.help");
     },
     translatedLabel() {
       const label = I18n.t("discourse_assign.reassign.title_w_ellipsis");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -43,6 +43,7 @@ en:
         title: "Re-assign"
         title_w_ellipsis: "Re-assign to..."
         to_self: "Re-assign to me"
+        to_self_help: "Re-assign Topic to me"
         help: "Re-assign Topic to a different user"
       reassign_modal:
         title: "Re-assign Topic"


### PR DESCRIPTION
- Update aria labels on mobile and for re-assign dropdown
- Fixes: https://dev.discourse.org/t/quicker-assign-to-self-when-group-is-assigned/54647/33?u=isaacjanzen
<img width="327" alt="Screen Shot 2021-11-19 at 11 33 19 AM" src="https://user-images.githubusercontent.com/50783505/142666169-602bd505-aa1f-458d-8f08-f4233235cc57.png">

