### PR TITLE
FIX: dont allow assigning user to topic when post assigned

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -181,21 +181,22 @@ class ::Assigner
   end
 
   def forbidden_reasons(assign_to:, type:)
-    forbidden_reason =
-      case
-      when assign_to.is_a?(User) && !can_assignee_see_target?(assign_to)
-        topic.private_message? ? :forbidden_assignee_not_pm_participant : :forbidden_assignee_cant_see_topic
-      when assign_to.is_a?(Group) && assign_to.users.any? { |user| !can_assignee_see_target?(user) }
-        topic.private_message? ? :forbidden_group_assignee_not_pm_participant : :forbidden_group_assignee_cant_see_topic
-      when !can_be_assigned?(assign_to)
-        assign_to.is_a?(User) ? :forbidden_assign_to : :forbidden_group_assign_to
-      when topic.assignment&.assigned_to_id == assign_to.id && topic.assignment&.assigned_to_type == type
-        assign_to.is_a?(User) ? :already_assigned : :group_already_assigned
-      when Assignment.where(topic: topic).count >= ASSIGNMENTS_PER_TOPIC_LIMIT
-        :too_many_assigns_for_topic
-      when !can_assign_to?(assign_to)
-        :too_many_assigns
-      end
+    case
+    when assign_to.is_a?(User) && !can_assignee_see_target?(assign_to)
+      topic.private_message? ? :forbidden_assignee_not_pm_participant : :forbidden_assignee_cant_see_topic
+    when assign_to.is_a?(Group) && assign_to.users.any? { |user| !can_assignee_see_target?(user) }
+      topic.private_message? ? :forbidden_group_assignee_not_pm_participant : :forbidden_group_assignee_cant_see_topic
+    when !can_be_assigned?(assign_to)
+      assign_to.is_a?(User) ? :forbidden_assign_to : :forbidden_group_assign_to
+    when topic.assignment&.assigned_to_id == assign_to.id && topic.assignment&.assigned_to_type == type
+      assign_to.is_a?(User) ? :already_assigned : :group_already_assigned
+    when @target.is_a?(Topic) && Assignment.where(topic_id: topic.id, target_type: "Post").any? { |assignment| assignment.assigned_to_id == assign_to.id && assignment.assigned_to_type == type }
+      assign_to.is_a?(User) ? :already_assigned : :group_already_assigned
+    when Assignment.where(topic: topic).count >= ASSIGNMENTS_PER_TOPIC_LIMIT
+      :too_many_assigns_for_topic
+    when !can_assign_to?(assign_to)
+      :too_many_assigns
+    end
   end
 
   def assign_or_reassign_target(assign_to:, type:, silent:, action_code:)

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -146,7 +146,7 @@ describe 'integration tests' do
     end
   end
 
-  context 'aleady assigned' do
+  context 'already assigned' do
     fab!(:post) { Fabricate(:post) }
     fab!(:post_2) { Fabricate(:post, topic: post.topic) }
     let(:topic) { post.topic }

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -146,6 +146,32 @@ describe 'integration tests' do
     end
   end
 
+  context 'aleady assigned' do
+    fab!(:post) { Fabricate(:post) }
+    fab!(:post_2) { Fabricate(:post, topic: post.topic) }
+    let(:topic) { post.topic }
+    fab!(:user) { Fabricate(:user) }
+
+    include_context 'A group that is allowed to assign'
+
+    it 'does not allow to assign topic if post is already assigned' do
+      add_to_assign_allowed_group(user)
+
+      assigner = Assigner.new(post, user)
+      response = assigner.assign(user)
+      expect(response[:success]).to be true
+
+      assigner = Assigner.new(post_2, user)
+      response = assigner.assign(user)
+      expect(response[:success]).to be true
+
+      assigner = Assigner.new(topic, user)
+      response = assigner.assign(user)
+      expect(response[:success]).to be false
+      expect(response[:reason]).to eq(:already_assigned)
+    end
+  end
+
   context 'move post' do
     fab!(:old_topic) { Fabricate(:topic) }
     fab!(:post) { Fabricate(:post, topic: old_topic) }


### PR DESCRIPTION
When post is already assigned to user/group then don't allow assigning a topic to that user/group.

Similarly, right now when topic is already assigned we are not allowing to assign a post that that user.