### PR TITLE
FIX: bulk assign modal was broken

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js.es6
@@ -904,7 +904,10 @@ export default {
         actions: {
           showReAssign() {
             this.set("assignUser.isBulkAction", true);
-            this.set("assignUser.model", { username: "" });
+            this.set("assignUser.model", {
+              username: "",
+              description: "discourse_assign.assign_bulk_modal.description",
+            });
             this.send("changeBulkTemplate", "modal/assign-user");
           },
           unassignTopics() {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -56,6 +56,8 @@ en:
       assign_post_modal:
         title: "Assign Post"
         description: "Enter the name of the user you'd like to assign this post"
+      assign_bulk_modal:
+        description: "Enter the name of the user you'd like to assign these topics"
       claim:
         title: "claim"
         help: "Assign topic to yourself"


### PR DESCRIPTION
When trying to bulk assign topics to a user via bulk topics action modal
the modal was broken because the key "model.description" was missing.

This commit adds key "model.description" and adds a new locale for it to
indicate that this action will be performed on multiple topics.