### PR TITLE
FEATURE: holiday icon for suggestions

### DIFF
--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -21,6 +21,7 @@
       {{#each assignSuggestions as |user|}}
         <a href {{action "assignUser" user.username }}>
           {{avatar user imageSize="small"}}
+          {{decorate-username-selector user.username}}
         </a>
       {{/each}}
     </div>

--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -89,6 +89,13 @@
       margin-right: 5px;
     }
   }
+
+  .on-holiday {
+    position: absolute;
+    margin-left: -18px;
+    margin-top: 14px;
+    color: var(--primary-medium);
+  }
 }
 
 .topic-list-item {


### PR DESCRIPTION
When user is on holiday, mark avatar with calendar icon.
In this case, urgent topics can be assigned to an available team member.

<img width="422" alt="Screen Shot 2022-01-10 at 9 30 12 am" src="https://user-images.githubusercontent.com/72780/148742373-1525c103-1721-4ba5-ad20-fdc793b529a2.png">
