### PR TITLE
FIX: don't display inactive assignments

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -81,7 +81,7 @@ module DiscourseAssign
 
       Topic.preload_custom_fields(topics, TopicList.preloaded_custom_fields)
 
-      topic_assignments = Assignment.where(target_id: topics.map(&:id), target_type: 'Topic').pluck(:target_id, :assigned_to_id).to_h
+      topic_assignments = Assignment.where(target_id: topics.map(&:id), target_type: 'Topic', active: true).pluck(:target_id, :assigned_to_id).to_h
 
       users = User
         .where("users.id IN (?)", topic_assignments.values.uniq)

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -20,6 +20,7 @@ describe Search do
     let(:post3) { Fabricate(:post) }
     let(:post4) { Fabricate(:post) }
     let(:post5) { Fabricate(:post, topic: post4.topic) }
+    let(:post6) { Fabricate(:post) }
 
     before do
       add_to_assign_allowed_group(user)
@@ -29,6 +30,7 @@ describe Search do
       Assigner.new(post2.topic, user).assign(user2)
       Assigner.new(post3.topic, user).assign(user)
       Assigner.new(post5, user).assign(user)
+      Assignment.create!(assigned_to: user, assigned_by_user: user, target: post6, topic_id: post6.topic.id, active: false)
     end
 
     it 'can find by status' do
@@ -36,7 +38,7 @@ describe Search do
 
       Assigner.new(post3.topic, user).unassign
 
-      expect(Search.execute('in:unassigned', guardian: Guardian.new(user)).posts.length).to eq(1)
+      expect(Search.execute('in:unassigned', guardian: Guardian.new(user)).posts.length).to eq(2)
       expect(Search.execute("assigned:#{user.username}", guardian: Guardian.new(user)).posts.length).to eq(2)
     end
 

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -38,6 +38,14 @@ describe TopicQuery do
       expect(assigned_messages).to contain_exactly(private_message, topic, group_topic)
     end
 
+    it 'Excludes inactive assignments' do
+      Assignment.update_all(active: false)
+
+      assigned_messages = TopicQuery.new(user, { page: 0 }).list_messages_assigned(user).topics
+
+      expect(assigned_messages).to eq([])
+    end
+
     it 'Excludes topics and PMs not assigned to user' do
       assigned_messages = TopicQuery.new(user2, { page: 0 }).list_messages_assigned(user2).topics
 


### PR DESCRIPTION
There is an active flag for assignments. It is used to bring assignments back when topic is reopened.

However, when assignment is inactive, it should not be displayed on assigned list or search.