### PR TITLE
FIX: Count and show only active assignments

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -118,7 +118,7 @@ module DiscourseAssign
         .joins("LEFT OUTER JOIN assignments a ON a.assigned_to_id = users.id AND a.assigned_to_type = 'User'")
         .joins("LEFT OUTER JOIN topics t ON t.id = a.target_id AND a.target_type = 'Topic'")
         .where("g.group_id = ? AND users.id > 0 AND t.deleted_at IS NULL", group.id)
-        .where("a.assigned_to_id IS NOT NULL")
+        .where("a.assigned_to_id IS NOT NULL AND a.active")
         .order('COUNT(users.id) DESC')
         .group('users.id')
         .select('users.*, COUNT(users.id) as "assignments_count"')
@@ -134,7 +134,7 @@ module DiscourseAssign
       group_assignments = Topic
         .joins("JOIN assignments a ON a.topic_id = topics.id")
         .where(<<~SQL, group_id: group.id)
-          a.assigned_to_id = :group_id AND a.assigned_to_type = 'Group'
+          a.assigned_to_id = :group_id AND a.assigned_to_type = 'Group' AND a.active
         SQL
         .pluck(:topic_id)
 
@@ -143,6 +143,7 @@ module DiscourseAssign
         .joins("JOIN group_users ON group_users.user_id = a.assigned_to_id ")
         .where("group_users.group_id = ?", group.id)
         .where("a.assigned_to_type = 'User'")
+        .where("a.active")
         .pluck(:topic_id)
 
       render json: {

--- a/plugin.rb
+++ b/plugin.rb
@@ -345,15 +345,14 @@ after_initialize do
     topic_ids_sql = +<<~SQL
       SELECT topic_id FROM assignments
       WHERE (
-        assigned_to_id = :group_id AND assigned_to_type = 'Group'
+        assigned_to_id = :group_id AND assigned_to_type = 'Group' AND active
       )
-      AND active
     SQL
 
     if @options[:filter] != :direct
       topic_ids_sql << <<~SQL
         OR (
-          assigned_to_id IN (SELECT user_id from group_users where group_id = :group_id) AND assigned_to_type = 'User'
+          assigned_to_id IN (SELECT user_id from group_users where group_id = :group_id) AND assigned_to_type = 'User' AND active
         )
       SQL
     end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -71,7 +71,7 @@ describe ListController do
       Assignment.where(assigned_to: user, target: topic1).update_all(active: false)
 
       get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json"
-      expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to eq([])
+      expect(response.parsed_body['topic_list']['topics']).to be_empty
     end
 
     it 'returns empty user-assigned-topics-list for users not in the assigned_allowed_group' do

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -67,6 +67,13 @@ describe ListController do
       expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['assigned_to_user']['id'] }).to match_array([user.id])
     end
 
+    it 'returns user-assigned-topics-list of users in the assigned_allowed_group and doesnt include inactive topics' do
+      Assignment.where(assigned_to: user, target: topic1).update_all(active: false)
+
+      get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json"
+      expect(JSON.parse(response.body)['topic_list']['topics'].map { |t| t['id'] }).to eq([])
+    end
+
     it 'returns empty user-assigned-topics-list for users not in the assigned_allowed_group' do
       ids = []
       get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json"


### PR DESCRIPTION
After a topic is closed, the assignment is not deleted but becomes
inactive. When this happened, it was not removed from the assignments
count or list.