### PR TITLE
FIX: better group assign message

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -32,6 +32,7 @@ en:
     flag_assigned: "Sorry, that flag's topic is assigned to another user"
     flag_unclaimed: "You must claim that topic before acting on the flag"
     topic_assigned_excerpt: "assigned you the topic '%{title}'"
+    topic_group_assigned_excerpt: "assigned to %{group} the topic '%{title}'"
     reminders_frequency:
       never: "never"
       daily: "daily"

--- a/jobs/regular/assign_notification.rb
+++ b/jobs/regular/assign_notification.rb
@@ -21,14 +21,18 @@ module Jobs
 
         next if assigned_by == user
 
+        assigned_to_user = args[:assigned_to_type] == "User"
+
         PostAlerter.new(post).create_notification_alert(
           user: user,
           post: post,
           username: assigned_by.username,
           notification_type: Notification.types[:custom],
-          excerpt: I18n.t(
-            "discourse_assign.topic_assigned_excerpt",
+          excerpt:
+          I18n.t(
+            (assigned_to_user ? "discourse_assign.topic_assigned_excerpt" : "discourse_assign.topic_group_assigned_excerpt"),
             title: topic.title,
+            group: assigned_to.name,
             locale: user.effective_locale
           )
         )
@@ -41,8 +45,8 @@ module Jobs
           post_number: post.post_number,
           high_priority: true,
           data: {
-            message: args[:assigned_to_type] == "User" ? 'discourse_assign.assign_notification' : 'discourse_assign.assign_group_notification',
-            display_username: args[:assigned_to_type] == "User" ? assigned_by.username : assigned_to.name,
+            message: assigned_to_user ? 'discourse_assign.assign_notification' : 'discourse_assign.assign_group_notification',
+            display_username: assigned_to_user ? assigned_by.username : assigned_to.name,
             topic_title: topic.title
           }.to_json
         )

--- a/spec/jobs/regular/assign_notification_spec.rb
+++ b/spec/jobs/regular/assign_notification_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Jobs::AssignNotification do
   describe '#execute' do
     fab!(:user1) { Fabricate(:user, last_seen_at: 1.day.ago) }
     fab!(:user2) { Fabricate(:user, last_seen_at: 1.day.ago) }
-    fab!(:topic) { Fabricate(:topic) }
+    fab!(:topic) { Fabricate(:topic, title: 'Basic topic title') }
     fab!(:post) { Fabricate(:post, topic: topic) }
     fab!(:pm_post) { Fabricate(:private_message_post) }
     fab!(:pm) { pm_post.topic }
@@ -33,7 +33,7 @@ RSpec.describe Jobs::AssignNotification do
         end
 
         expect(messages.length).to eq(1)
-        expect(messages.first.data[:excerpt]).to eq("assigned you the topic '#{topic.title}'")
+        expect(messages.first.data[:excerpt]).to eq("assigned you the topic 'Basic topic title'")
       end
 
       it 'should publish the right message when private message' do
@@ -65,7 +65,7 @@ RSpec.describe Jobs::AssignNotification do
     context 'Group' do
       fab!(:user3) { Fabricate(:user, last_seen_at: 1.day.ago) }
       fab!(:user4) { Fabricate(:user, suspended_till: 1.year.from_now) }
-      fab!(:group) { Fabricate(:group) }
+      fab!(:group) { Fabricate(:group, name: 'Developers') }
       let(:assignment) { Assignment.create!(topic: topic, assigned_by_user: user1, assigned_to: group) }
 
       before do
@@ -79,13 +79,13 @@ RSpec.describe Jobs::AssignNotification do
           described_class.new.execute({ topic_id: topic.id, post_id: post.id, assigned_to_id: group.id, assigned_to_type: 'Group', assigned_by_id: user1.id, silent: false })
         end
         expect(messages.length).to eq(1)
-        expect(messages.first.data[:excerpt]).to eq("assigned to #{group.name} the topic '#{topic.title}'")
+        expect(messages.first.data[:excerpt]).to eq("assigned to Developers the topic 'Basic topic title'")
 
         messages = MessageBus.track_publish("/notification-alert/#{user3.id}") do
           described_class.new.execute({ topic_id: topic.id, post_id: post.id, assigned_to_id: group.id, assigned_to_type: 'Group', assigned_by_id: user1.id, silent: false })
         end
         expect(messages.length).to eq(1)
-        expect(messages.first.data[:excerpt]).to eq("assigned to #{group.name} the topic '#{topic.title}'")
+        expect(messages.first.data[:excerpt]).to eq("assigned to Developers the topic 'Basic topic title'")
 
         messages = MessageBus.track_publish("/notification-alert/#{user4.id}") do
           described_class.new.execute({ topic_id: topic.id, post_id: post.id, assigned_to_id: group.id, assigned_to_type: 'Group', assigned_by_id: user1.id, silent: false })

--- a/spec/jobs/regular/assign_notification_spec.rb
+++ b/spec/jobs/regular/assign_notification_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe Jobs::AssignNotification do
           described_class.new.execute({ topic_id: topic.id, post_id: post.id, assigned_to_id: group.id, assigned_to_type: 'Group', assigned_by_id: user1.id, silent: false })
         end
         expect(messages.length).to eq(1)
-        expect(messages.first.data[:excerpt]).to eq("assigned you the topic '#{topic.title}'")
+        expect(messages.first.data[:excerpt]).to eq("assigned to #{group.name} the topic '#{topic.title}'")
 
         messages = MessageBus.track_publish("/notification-alert/#{user3.id}") do
           described_class.new.execute({ topic_id: topic.id, post_id: post.id, assigned_to_id: group.id, assigned_to_type: 'Group', assigned_by_id: user1.id, silent: false })
         end
         expect(messages.length).to eq(1)
-        expect(messages.first.data[:excerpt]).to eq("assigned you the topic '#{topic.title}'")
+        expect(messages.first.data[:excerpt]).to eq("assigned to #{group.name} the topic '#{topic.title}'")
 
         messages = MessageBus.track_publish("/notification-alert/#{user4.id}") do
           described_class.new.execute({ topic_id: topic.id, post_id: post.id, assigned_to_id: group.id, assigned_to_type: 'Group', assigned_by_id: user1.id, silent: false })


### PR DESCRIPTION
When topic is assigned to group, then notification should be different to distinguish from direct assignments.