### PR TITLE
FIX: Exclude inactive assignments from assigned_total count

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -138,7 +138,7 @@ class ::Assigner
     assigned_total = Assignment
       .joins_with_topics
       .where(topics: { deleted_at: nil })
-      .where(assigned_to_id: assign_to.id)
+      .where(assigned_to_id: assign_to.id, active: true)
       .count
 
     assigned_total < SiteSetting.max_assigned_topics

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -160,6 +160,20 @@ RSpec.describe Assigner do
       expect(third_assign[:success]).to eq(true)
     end
 
+    it "doesn't count inactive assigns when enforcing the limit" do
+      SiteSetting.max_assigned_topics = 1
+      SiteSetting.unassign_on_close = true
+      another_post = Fabricate(:post)
+
+      first_assign = assigner.assign(moderator)
+      topic.update_status("closed", true, Discourse.system_user)
+
+      second_assign = described_class.new(another_post.topic, moderator_2).assign(moderator)
+
+      expect(first_assign[:success]).to eq(true)
+      expect(second_assign[:success]).to eq(true)
+    end
+
     fab!(:admin) { Fabricate(:admin) }
 
     it 'fails to assign when the assigned user cannot view the pm' do


### PR DESCRIPTION
If `SiteSetting.unassign_on_close` is enabled, an Assignment record can still exist, but be set to inactive, when a Topic is closed.

Inactivement Assignments should be ignored when comparing to the maximum permitted number of assigned topics.