### PR TITLE
A11Y: Use `autocomplete=off` for search inputs

### DIFF
--- a/assets/javascripts/discourse/templates/group-topics-list.hbs
+++ b/assets/javascripts/discourse/templates/group-topics-list.hbs
@@ -5,7 +5,8 @@
       value=(readonly search)
       placeholder=(i18n "discourse_assign.topic_search_placeholder")
       input=(action "onChangeFilter" value="target.value")
-      autocomplete="discourse"
+      autocomplete="off"
+      type="search"
     }}
   </div>
 </div>

--- a/assets/javascripts/discourse/templates/user-assigned-topics.hbs
+++ b/assets/javascripts/discourse/templates/user-assigned-topics.hbs
@@ -11,7 +11,8 @@
         value=(readonly search)
         placeholder=(i18n "discourse_assign.topic_search_placeholder")
         input=(action "onChangeFilter" value="target.value")
-        autocomplete="discourse"
+        autocomplete="off"
+        type="search"
       }}
     </div>
   </div>


### PR DESCRIPTION
Follows core changes, more details in https://github.com/discourse/discourse/pull/15758. 