### PR TITLE
FIX: Reuse topic query method to find group topics

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -138,13 +138,10 @@ module DiscourseAssign
         SQL
         .pluck(:topic_id)
 
-      assignments = Topic
-        .joins("JOIN assignments a ON a.topic_id = topics.id")
-        .joins("JOIN group_users ON group_users.user_id = a.assigned_to_id ")
-        .where("group_users.group_id = ?", group.id)
-        .where("a.assigned_to_type = 'User'")
-        .where("a.active")
-        .pluck(:topic_id)
+      assignments = TopicQuery
+        .new(current_user)
+        .group_topics_assigned_results(group)
+        .pluck('topics.id')
 
       render json: {
         members: serialize_data(members, GroupUserAssignedSerializer),

--- a/plugin.rb
+++ b/plugin.rb
@@ -339,8 +339,8 @@ after_initialize do
     create_list(:assigned, { unordered: true }, list)
   end
 
-  add_to_class(:topic_query, :list_group_topics_assigned) do |group|
-    list = default_results(include_pms: true)
+  add_to_class(:topic_query, :group_topics_assigned_results) do |group|
+    list = default_results(include_all_pms: true)
 
     topic_ids_sql = +<<~SQL
       SELECT topic_id FROM assignments
@@ -360,8 +360,10 @@ after_initialize do
     sql = "topics.id IN (#{topic_ids_sql})"
 
     list = list.where(sql, group_id: group.id).includes(:allowed_users)
+  end
 
-    create_list(:assigned, { unordered: true }, list)
+  add_to_class(:topic_query, :list_group_topics_assigned) do |group|
+    create_list(:assigned, { unordered: true }, group_topics_assigned_results(group))
   end
 
   add_to_class(:topic_query, :list_private_messages_assigned) do |user|


### PR DESCRIPTION
The query for counts and list were different and the count did not
match the number of topics from the list.

Needs https://github.com/discourse/discourse/pull/15742