### PR TITLE
DEV: Update .discourse-compatibility for stable branch.

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+2.8.1: 7bec9aeaf786defc9a133b8cb9ed24f1c2522400
 2.8.0.beta8: f901c5fe97c272c884c1e6cfdad1ad1cbe0b36be
 2.8.0.beta7: 3a8e45700ca6356fd55a4b88583cd8adeada14ad
 2.8.0.beta1: 54c670536c416ac1acfd6fb24d6aa0e48cc1ef18


### PR DESCRIPTION
https://github.com/discourse/discourse-assign/commit/c8fc42b60f42ccc8acc6257f3c3e7444ab5a6e61 uses an API in core that is not present in Version 2.8.1