### PR TITLE
DEV: Add acceptance tests for assignment notifications

### DIFF
--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -7,8 +7,10 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
+import I18n from "I18n";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import NotificationFixture from "../fixtures/notifications-fixtures";
 
 function assignCurrentUserToTopic(needs) {
   needs.pretender((server, helper) => {
@@ -39,6 +41,11 @@ function assignCurrentUserToTopic(needs) {
         name: "Developers",
       };
       return helper.response(topic);
+    });
+
+    server.get("/notifications?username=eviltrout&filter=all", () => {
+      const notifications = NotificationFixture["/assign/notifications/eviltrout"];
+      return helper.response(notifications);
     });
   });
 }
@@ -136,6 +143,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "shows reassign dropdown at the bottom of the topic"
     );
   });
+<<<<<<< HEAD
 
   test("User without assign ability cannot see footer button", async (assert) => {
     updateCurrentUser({ can_assign: false, admin: false, moderator: false });
@@ -146,6 +154,35 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "does not show reassign dropdown at the bottom of the topic"
     );
   });
+||||||| parent of 4233170 (first try)
+=======
+
+  test("Shows assignement notification", async (assert) => {
+    updateCurrentUser({ can_assign: true });
+
+    await visit("/u/eviltrout/notifications");
+
+    debugger;
+
+    let notification = query("section.user-content ul.notifications li.item.notification")[0];
+
+    assert.equal(
+      notification.children[0].classList,
+      "assigned",
+      "with correct assigned class"
+    );
+    assert.equal(
+      notification.querySelector('a').title,
+      I18n.t("notifications.title.assigned"),
+      "with correct title"
+    );
+    assert.equal(
+      notification.querySelector('svg use').href['baseVal'],
+      "#user-plus",
+      "with correct icon"
+    );
+  });
+>>>>>>> 4233170 (first try)
 });
 
 acceptance("Discourse Assign | Re-assign topic", function (needs) {

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -164,7 +164,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
 
     debugger;
 
-    let notification = query("section.user-content ul.notifications li.item.notification")[0];
+    let notification = query("section.user-content ul.notifications li.item.notification");
 
     assert.equal(
       notification.children[0].classList,

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -157,7 +157,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
 ||||||| parent of 4233170 (first try)
 =======
 
-  test("Shows assignement notification", async (assert) => {
+  test("Shows assignment notification", async function (assert) {
     updateCurrentUser({ can_assign: true });
 
     await visit("/u/eviltrout/notifications");

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -43,9 +43,10 @@ function assignCurrentUserToTopic(needs) {
       return helper.response(topic);
     });
 
-    server.get("/notifications?username=eviltrout&filter=all", () => {
-      const notifications = NotificationFixture["/assign/notifications/eviltrout"];
-      return helper.response(notifications);
+    server.get("/notifications", () => {
+      return helper.response(
+        NotificationFixture["/assign/notifications/eviltrout"]
+      );
     });
   });
 }
@@ -162,22 +163,23 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
 
     await visit("/u/eviltrout/notifications");
 
-    debugger;
-
-    let notification = query("section.user-content ul.notifications li.item.notification");
+    const notification = query(
+      "section.user-content ul.notifications li.item.notification"
+    );
 
     assert.equal(
       notification.children[0].classList,
       "assigned",
       "with correct assigned class"
     );
+
     assert.equal(
-      notification.querySelector('a').title,
-      I18n.t("notifications.title.assigned"),
+      notification.querySelector("a").title,
+      I18n.t("notifications.titles.assigned"),
       "with correct title"
     );
     assert.equal(
-      notification.querySelector('svg use').href['baseVal'],
+      notification.querySelector("svg use").href["baseVal"],
       "#user-plus",
       "with correct icon"
     );

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -144,7 +144,6 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "shows reassign dropdown at the bottom of the topic"
     );
   });
-<<<<<<< HEAD
 
   test("User without assign ability cannot see footer button", async (assert) => {
     updateCurrentUser({ can_assign: false, admin: false, moderator: false });
@@ -155,8 +154,6 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "does not show reassign dropdown at the bottom of the topic"
     );
   });
-||||||| parent of 4233170 (first try)
-=======
 
   test("Shows assignment notification", async function (assert) {
     updateCurrentUser({ can_assign: true });
@@ -184,7 +181,6 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "with correct icon"
     );
   });
->>>>>>> 4233170 (first try)
 });
 
 acceptance("Discourse Assign | Re-assign topic", function (needs) {

--- a/test/javascripts/fixtures/notifications-fixtures.js
+++ b/test/javascripts/fixtures/notifications-fixtures.js
@@ -1,0 +1,87 @@
+export default {
+  "/assign/notifications/eviltrout": {
+    notifications: [
+      {
+        id: 193,
+        user_id: 26,
+        notification_type: 34,
+        read: false,
+        high_priority: true,
+        created_at: "2022-03-18T17:51:11.920Z",
+        post_number: 1,
+        topic_id: 59,
+        fancy_title:
+          "A bear, however hard he tries, grows tubby without exercise",
+        slug: "a-bear-however-hard-he-tries-grows-tubby-without-exercise",
+        data: {
+          message: "discourse_assign.assign_notification",
+          display_username: "system",
+          topic_title:
+            "A bear, however hard he tries, grows tubby without exercise",
+        },
+      },
+      {
+        id: 192,
+        user_id: 26,
+        notification_type: 12,
+        read: false,
+        high_priority: false,
+        created_at: "2022-03-18T16:47:09.668Z",
+        post_number: null,
+        topic_id: null,
+        slug: null,
+        data: {
+          badge_id: 5,
+          badge_name: "Welcome",
+          badge_slug: "welcome",
+          badge_title: false,
+          username: "eviltrout",
+        },
+      },
+      {
+        id: 191,
+        user_id: 26,
+        notification_type: 5,
+        read: false,
+        high_priority: false,
+        created_at: "2022-03-18T16:46:57.744Z",
+        post_number: 5,
+        topic_id: 59,
+        fancy_title:
+          "A bear, however hard he tries, grows tubby without exercise",
+        slug: "a-bear-however-hard-he-tries-grows-tubby-without-exercise",
+        data: {
+          topic_title:
+            "A bear, however hard he tries, grows tubby without exercise",
+          original_post_id: 285,
+          original_post_type: 1,
+          original_username: "system",
+          revision_number: null,
+          display_username: "system",
+        },
+      },
+      {
+        id: 148,
+        user_id: 26,
+        notification_type: 12,
+        read: false,
+        high_priority: false,
+        created_at: "2022-03-17T21:49:02.226Z",
+        post_number: null,
+        topic_id: null,
+        slug: null,
+        data: {
+          badge_id: 1,
+          badge_name: "Basic",
+          badge_slug: "basic",
+          badge_title: false,
+          username: "eviltrout",
+        },
+      },
+    ],
+    total_rows_notifications: 4,
+    seen_notification_id: 193,
+    load_more_notifications:
+      "/notifications?filter=all&offset=60&username=eviltrout",
+  },
+};


### PR DESCRIPTION
Follow up of https://github.com/discourse/discourse-assign/pull/306#issuecomment-1071953653

@tgxworld Is this what you had in mind?

Can't get it to pass tho, any ideas @CvX ?