### PR TITLE
UX: Show posters on assigned topic list

### DIFF
--- a/assets/javascripts/discourse/templates/user-assigned-topics.hbs
+++ b/assets/javascripts/discourse/templates/user-assigned-topics.hbs
@@ -21,7 +21,7 @@
     {{basic-assigned-topic-list
       topicList=model
       hideCategory=hideCategory
-      showPosters=showPosters
+      showPosters=true
       bulkSelectEnabled=bulkSelectEnabled
       selected=selected
       hasIncoming=hasIncoming


### PR DESCRIPTION
The layout can support it, and this extra information seems useful. 

Related discussion: https://meta.discourse.org/t/show-last-poster-in-assignment-list/220298

Before:
<img width="1145" alt="Screen Shot 2022-04-14 at 3 57 19 PM" src="https://user-images.githubusercontent.com/1681963/163466214-8c79f17a-6fc3-4058-90a3-8bc21b62078b.png">

After:
<img width="1156" alt="Screen Shot 2022-04-14 at 3 57 07 PM" src="https://user-images.githubusercontent.com/1681963/163466221-875e720e-6161-4684-9aa9-0d9e46fd1547.png">
