### PR TITLE
FIX: Hide footer action button when user cannot assign

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -174,7 +174,11 @@ function registerTopicFooterButtons(api) {
     },
 
     displayed() {
-      return !this.site.mobileView && this.topic.isAssigned();
+      return (
+        this.get("currentUser.can_assign") &&
+        !this.site.mobileView &&
+        this.topic.isAssigned()
+      );
     },
   });
 

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -78,6 +78,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
     assign_enabled: true,
     tagging_enabled: true,
     assigns_user_url_path: "/",
+    assigns_public: true,
   });
 
   assignCurrentUserToTopic(needs);
@@ -124,7 +125,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
     );
   });
 
-  test("Public user cannot see footer button", async (assert) => {
+  test("User without assign ability cannot see footer button", async (assert) => {
     updateCurrentUser({ can_assign: false, admin: false, moderator: false });
     await visit("/t/assignment-topic/45");
 

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -123,6 +123,16 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
       "shows reassign dropdown at the bottom of the topic"
     );
   });
+
+  test("Public user cannot see footer button", async (assert) => {
+    updateCurrentUser({ can_assign: false, admin: false, moderator: false });
+    await visit("/t/assignment-topic/45");
+
+    assert.notOk(
+      exists("#topic-footer-dropdown-reassign"),
+      "shows reassign dropdown at the bottom of the topic"
+    );
+  });
 });
 
 acceptance("Discourse Assign | Re-assign topic", function (needs) {

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -130,7 +130,7 @@ acceptance("Discourse Assign | Assigned topic", function (needs) {
 
     assert.notOk(
       exists("#topic-footer-dropdown-reassign"),
-      "shows reassign dropdown at the bottom of the topic"
+      "does not show reassign dropdown at the bottom of the topic"
     );
   });
 });


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/public-assigns-shows-reassign-button/224860

> When “public assigns” is enabled in the assign plugin, a regular user sees a drop down button which looks like they are able to reassign the topic. The button does not actually work though.