### PR TITLE
UX: show posters on group assign list

### DIFF
--- a/assets/javascripts/discourse/templates/components/assigned-topic-list.hbs
+++ b/assets/javascripts/discourse/templates/components/assigned-topic-list.hbs
@@ -5,7 +5,7 @@
       canDoBulkActions=canDoBulkActions
       toggleInTitle=toggleInTitle
       hideCategory=hideCategory
-      showPosters=showPosters
+      showPosters=true
       showLikes=showLikes
       showOpLikes=showOpLikes
       order=order
@@ -24,7 +24,7 @@
       bulkSelectEnabled=bulkSelectEnabled
       showTopicPostBadges=showTopicPostBadges
       hideCategory=hideCategory
-      showPosters=showPosters
+      showPosters=true
       showLikes=showLikes
       showOpLikes=showOpLikes
       expandGloballyPinned=expandGloballyPinned


### PR DESCRIPTION
I previously had enabled these on the user assigned topic list, and there's space to show them on the group assigned list as well. Consistency!

Before:

![Screen Shot 2022-04-29 at 1 24 29 PM](https://user-images.githubusercontent.com/1681963/165993321-7109395f-d459-4fe6-ac4d-05989c4f8787.png)

After:

![Screen Shot 2022-04-29 at 1 24 18 PM](https://user-images.githubusercontent.com/1681963/165993341-2e01b90e-5f47-4d8c-83a8-108a38d50a72.png)


User assigns (changed to match this): 
![Screen Shot 2022-04-29 at 1 25 29 PM](https://user-images.githubusercontent.com/1681963/165993409-bf9a694c-e4bb-49ad-8e80-06ef62a1bd9b.png)

