### PR TITLE
FIX: Assigning a user without notes assigns and closes the modal

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/assign-user.js
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js
@@ -19,6 +19,9 @@ export default Controller.extend({
     this.allowedGroups = [];
 
     ajax("/assign/suggestions").then((data) => {
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
       this.set("assignSuggestions", data.suggestions);
       this.set("allowedGroups", data.assign_allowed_on_groups);
       this.set("allowedGroupsForAssignment", data.assign_allowed_for_groups);

--- a/assets/javascripts/discourse-assign/controllers/assign-user.js
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js
@@ -100,6 +100,10 @@ export default Controller.extend({
         "model.allowedGroups": this.taskActions.allowedGroups,
       });
     }
+
+    if (name) {
+      return this.assign();
+    }
   },
 
   @action

--- a/test/javascripts/controllers/assign-user-test.js
+++ b/test/javascripts/controllers/assign-user-test.js
@@ -2,14 +2,12 @@ import EmberObject from "@ember/object";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
+import { Promise } from "rsvp";
 
-discourseModule("Unit | Controller | assign-user", function (hooks) {
-  hooks.beforeEach(function () {});
-
+discourseModule("Unit | Controller | assign-user", function () {
   test("doesn't set suggestions and fails gracefully if controller is destroyed", function (assert) {
     let resolveSuggestions;
     pretender.get("/assign/suggestions", () => {
-      // eslint-disable-next-line no-restricted-globals
       return new Promise((resolve) => {
         resolveSuggestions = resolve;
       });

--- a/test/javascripts/controllers/assign-user-test.js
+++ b/test/javascripts/controllers/assign-user-test.js
@@ -1,0 +1,42 @@
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import pretender from "discourse/tests/helpers/create-pretender";
+import EmberObject from "@ember/object";
+
+discourseModule("Unit | Controller | assign-user", function (hooks) {
+  hooks.beforeEach(function () {
+    pretender.get("/assign/suggestions", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        {
+          suggestions: [],
+          assign_allowed_on_groups: [],
+          assign_allowed_for_groups: [],
+        },
+      ];
+    });
+
+    pretender.put("/assign/assign", () => {
+      return [200, { "Content-Type": "application/json" }, {}];
+    });
+  });
+
+  test("assigning a user closes the modal", function (assert) {
+    let modalClosed = false;
+    const controller = this.getController("assign-user", {
+      model: {
+        target: EmberObject.create({}),
+      },
+      allowedGroupsForAssignment: ["nat"],
+      taskActions: { allowedGroups: [] },
+    });
+    controller.set("actions.closeModal", () => {
+      modalClosed = true;
+    });
+
+    controller.send("assignUser", "nat");
+
+    assert.strictEqual(modalClosed, true);
+  });
+});


### PR DESCRIPTION
Quite literally it.

Previously, clicking on the user suggestion immediately triggered the assign and closes the modal. It was reverted (https://github.com/discourse/discourse-assign/pull/326) because there was an additional note box to fill in. But folks prefer immediately assigning despite notes not filled 🤷‍♀️ 