### PR TITLE
FEATURE: Shows note in moderator post

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -15,6 +15,7 @@ en:
       unassigned_group_from_post: "unassigned %{who} from <a href='%{path}'>post</a> %{when}"
       reassigned: "Reassigned %{who} %{when}"
       reassigned_group: "Reassigned %{who} %{when}"
+      note_change: "changed assignment note for %{who} %{when}"
     discourse_assign:
       add_unassigned_filter: "Add 'unassigned' filter to category"
       cant_act: "You cannot act on flags that have been assigned to other users"

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -258,7 +258,7 @@ class ::Assigner
 
       topic.add_moderator_post(
         @assigned_by,
-        nil,
+        note,
         bump: false,
         post_type: SiteSetting.assigns_public ? Post.types[:small_action] : Post.types[:whisper],
         action_code: moderator_post_assign_action_code(assignment, action_code),

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Assigner do
       expect(topic.assignment.note).to eq "tomtom best mom"
     end
 
+    it "assign with note adds moderator post with note" do
+      expect { assigner.assign(moderator, note: "tomtom best mom") }.to change { topic.posts.count }.by(1)
+      expect(topic.posts.last.raw).to eq "tomtom best mom"
+    end
+
     it "publishes topic assignment after assign and unassign" do
       messages = MessageBus.track_publish('/staff/topic-assignment') do
         assigner = described_class.new(topic, moderator_2)


### PR DESCRIPTION
Shows the assignment note in moderator post.

Note there were no migrations to retroactively add the notes into small action posts
- A small action post generated from assignment has no relation to its topic/post
  - its `PostCustomField`s used in assign are used elsewhere as well (e.g. `action_code_who` etc)
- Vice versa, an assignment does not have relationship to its generated small action post

Each note modification also adds a moderator post, rather than modify the previous post. If we wish to have that, it's possible too.

<img width="496" alt="Screenshot 2022-05-12 at 10 21 14 PM" src="https://user-images.githubusercontent.com/1555215/168097273-7a1af897-902d-470e-8836-f3d6af50005b.png">

