### PR TITLE
FEATURE: Promote polymorphic bookmarks

### DIFF
--- a/spec/serializers/user_bookmark_base_serializer_spec.rb
+++ b/spec/serializers/user_bookmark_base_serializer_spec.rb
@@ -7,7 +7,6 @@ describe UserBookmarkBaseSerializer do
   include_context 'A group that is allowed to assign'
 
   before do
-    SiteSetting.use_polymorphic_bookmarks = true
     SiteSetting.assign_enabled = true
     add_to_assign_allowed_group(user)
   end
@@ -19,7 +18,7 @@ describe UserBookmarkBaseSerializer do
 
   context "for Topic bookmarkable" do
     let!(:bookmark) { Fabricate(:bookmark, user: user, bookmarkable: post.topic) }
-    xit "includes assigned user in serializer" do
+    it "includes assigned user in serializer" do
       Assigner.new(topic, user).assign(user)
       serializer = UserTopicBookmarkSerializer.new(bookmark, scope: guardian)
       bookmark = serializer.as_json[:user_topic_bookmark]
@@ -29,7 +28,7 @@ describe UserBookmarkBaseSerializer do
       expect(bookmark[:assigned_to_group]).to be(nil)
     end
 
-    xit "includes assigned group in serializer" do
+    it "includes assigned group in serializer" do
       Assigner.new(topic, user).assign(assign_allowed_group)
       serializer = UserTopicBookmarkSerializer.new(bookmark, scope: guardian)
       bookmark = serializer.as_json[:user_topic_bookmark]
@@ -42,7 +41,7 @@ describe UserBookmarkBaseSerializer do
 
   context "for Post bookmarkable" do
     let!(:bookmark) { Fabricate(:bookmark, user: user, bookmarkable: post) }
-    xit "includes assigned user in serializer" do
+    it "includes assigned user in serializer" do
       Assigner.new(topic, user).assign(user)
       serializer = UserPostBookmarkSerializer.new(bookmark, scope: guardian)
       bookmark = serializer.as_json[:user_post_bookmark]
@@ -52,7 +51,7 @@ describe UserBookmarkBaseSerializer do
       expect(bookmark[:assigned_to_group]).to be(nil)
     end
 
-    xit "includes assigned group in serializer" do
+    it "includes assigned group in serializer" do
       Assigner.new(topic, user).assign(assign_allowed_group)
       serializer = UserPostBookmarkSerializer.new(bookmark, scope: guardian)
       bookmark = serializer.as_json[:user_post_bookmark]


### PR DESCRIPTION
This removes the use_polymorphic_bookmarks site setting
guard and promotes that code to the only code used.