### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/user-activity-assigned.js
+++ b/assets/javascripts/discourse-assign/controllers/user-activity-assigned.js
@@ -8,6 +8,7 @@ import { action } from "@ember/object";
 import getURL from "discourse-common/lib/get-url";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
 
 export default UserTopicsList.extend({
   user: controller(),
@@ -29,10 +30,12 @@ export default UserTopicsList.extend({
 
   @discourseComputed
   emptyStateBody() {
-    return I18n.t("user.no_assignments_body", {
-      preferencesUrl: getURL("/my/preferences/notifications"),
-      icon: iconHTML("user-plus"),
-    }).htmlSafe();
+    return htmlSafe(
+      I18n.t("user.no_assignments_body", {
+        preferencesUrl: getURL("/my/preferences/notifications"),
+        icon: iconHTML("user-plus"),
+      })
+    );
   },
 
   refreshModel() {

--- a/assets/javascripts/discourse/widgets/quick-access-assignments.js
+++ b/assets/javascripts/discourse/widgets/quick-access-assignments.js
@@ -9,6 +9,7 @@ import getURL from "discourse-common/lib/get-url";
 import { postUrl } from "discourse/lib/utilities";
 import { h } from "virtual-dom";
 import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
 
 const ICON = "user-plus";
 const GROUP_ICON = "group-plus";
@@ -22,10 +23,12 @@ createWidget("no-quick-access-assignments", {
         new RawHtml({
           html:
             "<p>" +
-            I18n.t("user.no_assignments_body", {
-              preferencesUrl: getURL("/my/preferences/notifications"),
-              icon: iconHTML(ICON),
-            }).htmlSafe() +
+            htmlSafe(
+              I18n.t("user.no_assignments_body", {
+                preferencesUrl: getURL("/my/preferences/notifications"),
+                icon: iconHTML(ICON),
+              })
+            ) +
             "</p>",
         })
       ),


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions