### PR TITLE
UX: don't mention the group when no one is assigned.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -73,7 +73,7 @@ en:
     scriptables:
       random_assign:
         title: Random assign
-        no_one: "Attempted randomly assign a member of @%{group}, but no one was available."
+        no_one: "Attempted randomly assign a member of `@%{group}`, but no one was available."
   discourse_push_notifications:
     popup:
       assigned: "@%{username} assigned you"

--- a/spec/lib/random_assign_utils_spec.rb
+++ b/spec/lib/random_assign_utils_spec.rb
@@ -34,7 +34,7 @@ describe RandomAssignUtils do
 
       it 'creates post on the topic' do
         described_class.automation_script!({}, { 'assignees_group' => { 'value' => group_1.id }, 'assigned_topic' => { 'value' => topic_1.id } }, automation)
-        expect(topic_1.posts.first.raw).to match("Attempted randomly assign a member of @#{group_1.name}, but no one was available.")
+        expect(topic_1.posts.first.raw).to match("Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.")
       end
     end
 
@@ -50,7 +50,7 @@ describe RandomAssignUtils do
 
       it 'creates post on the topic' do
         described_class.automation_script!({}, { 'assignees_group' => { 'value' => group_1.id }, 'assigned_topic' => { 'value' => topic_1.id } }, automation)
-        expect(topic_1.posts.first.raw).to match("Attempted randomly assign a member of @#{group_1.name}, but no one was available.")
+        expect(topic_1.posts.first.raw).to match("Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.")
       end
     end
 
@@ -94,7 +94,7 @@ describe RandomAssignUtils do
 
       it 'creates post on the topic' do
         described_class.automation_script!({}, { 'in_working_hours' => { 'value' => true }, 'assignees_group' => { 'value' => group_1.id }, 'assigned_topic' => { 'value' => topic_1.id } }, automation)
-        expect(topic_1.posts.first.raw).to match("Attempted randomly assign a member of @#{group_1.name}, but no one was available.")
+        expect(topic_1.posts.first.raw).to match("Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.")
       end
     end
 


### PR DESCRIPTION
It's a minor copyedit to remove group mention from the post raw. Else it sends a notification to all group members when no one is found to be assigned.