### PR TITLE
FIX: include users who were assigned to a post instead of topic.

### DIFF
--- a/lib/random_assign_utils.rb
+++ b/lib/random_assign_utils.rb
@@ -112,7 +112,7 @@ class RandomAssignUtils
   def self.recently_assigned_users_ids(topic_id, from)
     posts = Post
       .joins(:user)
-      .where(topic_id: topic_id, action_code: ['assigned', 'reassigned'])
+      .where(topic_id: topic_id, action_code: ['assigned', 'reassigned', 'assigned_to_post'])
       .where('posts.created_at > ?', from)
       .order(created_at: :desc)
     usernames = Post.custom_fields_for_ids(posts, [:action_code_who]).map { |_, v| v['action_code_who'] }.uniq

--- a/spec/lib/random_assign_utils_spec.rb
+++ b/spec/lib/random_assign_utils_spec.rb
@@ -165,11 +165,14 @@ describe RandomAssignUtils do
       let(:user_1) { Fabricate(:user, groups: [assign_allowed_group]) }
       let(:user_2) { Fabricate(:user, groups: [assign_allowed_group]) }
       let(:user_3) { Fabricate(:user, groups: [assign_allowed_group]) }
+      let(:user_4) { Fabricate(:user, groups: [assign_allowed_group]) }
+      let(:post_2) { Fabricate(:post, topic: post.topic) }
 
       it 'returns the recently assigned user ids' do
         freeze_time 1.months.ago do
           Assigner.new(post.topic, admin).assign(user_1)
           Assigner.new(post.topic, admin).assign(user_2)
+          Assigner.new(post_2, admin).assign(user_4)
         end
 
         freeze_time 3.months.ago do
@@ -178,7 +181,7 @@ describe RandomAssignUtils do
 
         assignees_ids = described_class.recently_assigned_users_ids(post.topic_id, 2.months.ago)
 
-        expect(assignees_ids).to contain_exactly(user_1.id, user_2.id)
+        expect(assignees_ids).to contain_exactly(user_1.id, user_2.id, user_4.id)
       end
     end
   end


### PR DESCRIPTION
While assigning a random user in group to the topic posts, if we didn't include the users who were assigned to indivitual posts then the same users will be assigned again and again.