### PR TITLE
FIX: ensure that assignee is participant of pm

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -160,7 +160,12 @@ class ::Assigner
     @post_target ||= @target.is_a?(Post)
   end
 
+  def private_message_allowed_user_ids
+    @private_message_allowed_user_ids ||= topic.all_allowed_users.map(&:id)
+  end
+
   def can_assignee_see_target?(assignee)
+    return false if (topic_target? || post_target?) && topic.private_message? && !private_message_allowed_user_ids.include?(assignee.id)
     return Guardian.new(assignee).can_see_topic?(@target) if topic_target?
     return Guardian.new(assignee).can_see_post?(@target) if post_target?
 

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -161,7 +161,7 @@ class ::Assigner
   end
 
   def private_message_allowed_user_ids
-    @private_message_allowed_user_ids ||= topic.all_allowed_users.map(&:id)
+    @private_message_allowed_user_ids ||= topic.all_allowed_users.pluck(:id)
   end
 
   def can_assignee_see_target?(assignee)

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -24,6 +24,7 @@ describe TopicQuery do
       [user_pm, admin_pm, other_admin_pm].each do |topic|
         Fabricate(:post, topic: topic)
       end
+      Fabricate(:topic_allowed_user, user: admin, topic: user_pm)
 
       Assigner.new(user_pm, Discourse.system_user).assign(admin)
       Assigner.new(admin_pm, Discourse.system_user).assign(admin)


### PR DESCRIPTION
We are already checking that assignee has access to the private message. However, admin still can be assigned as technically they have access.

We should ensure that assignee has direct access to the message.