### PR TITLE
FEATURE: Allows note to be edited

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -580,7 +580,7 @@ function initialize(api) {
       ].includes(transformed.actionCode)
     ) {
       transformed.isSmallAction = true;
-      transformed.canEdit = false;
+      transformed.canEdit = true;
     }
   });
 


### PR DESCRIPTION
<img width="762" alt="Screenshot 2022-06-17 at 11 54 43 PM" src="https://user-images.githubusercontent.com/1555215/174333826-9f076ca7-7899-4dac-b2eb-c81f385e804f.png">

I initially wrote a widget test for 
```
Component | Widget | transformed post-stream
```
but ultimately ditched it as the `componentTest` initialization was not working out well with the plugin initializer. Essentially I had to set some site-settings in the test setup, but it triggered too late in the flow to test the side effect.