### PR TITLE
FIX: Fix a bug where a note change was ending in a full blown whisper

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -577,6 +577,7 @@ function initialize(api) {
         "assigned_group_to_post",
         "unassigned_from_post",
         "unassigned_group_from_post",
+        "note_change",
       ].includes(transformed.actionCode)
     ) {
       transformed.isSmallAction = true;


### PR DESCRIPTION
Unfortunately, similar to https://github.com/discourse/discourse-assign/pull/350, this line is not easily testable due to plugin initialization occurring before `beforeEach`.

## Before

<img width="777" alt="Screenshot 2022-06-18 at 1 35 15 AM" src="https://user-images.githubusercontent.com/1555215/174349780-53f69ecb-6e36-4448-bca5-fc219e8d1395.png">

## After

<img width="761" alt="Screenshot 2022-06-18 at 1 35 50 AM" src="https://user-images.githubusercontent.com/1555215/174349785-9931b1d1-2779-4efc-b343-85e2247b2b38.png">

