### PR TITLE
UX: Don't display assign user menu glyph when sidebar is enabled

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -649,7 +649,11 @@ function initialize(api) {
   });
 
   api.addUserMenuGlyph((widget) => {
-    if (widget.currentUser && widget.currentUser.can_assign) {
+    if (
+      widget.currentUser &&
+      widget.currentUser.can_assign &&
+      !widget.currentUser.experimental_sidebar_enabled
+    ) {
       const glyph = {
         label: "discourse_assign.assigned",
         className: "assigned",

--- a/test/javascripts/acceptance/assign-sidebar-test.js
+++ b/test/javascripts/acceptance/assign-sidebar-test.js
@@ -5,6 +5,7 @@ import {
   acceptance,
   exists,
   query,
+  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import AssignedTopics from "../fixtures/assigned-topics-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
@@ -24,6 +25,27 @@ acceptance(
     });
   }
 );
+
+acceptance("Discourse Assign | Sidebar | User Menu", function (needs) {
+  needs.user({ experimental_sidebar_enabled: true, can_assign: true });
+  needs.settings({ assign_enabled: true });
+
+  test("assign user menu is not displayed when user has enabled sidebar", async function (assert) {
+    await visit("/");
+    await click(".header-dropdown-toggle.current-user");
+
+    assert.ok(!exists(".assigned.menu-link"));
+  });
+
+  test("assign user menu glyph is displayed when user has disabled sidebar", async function (assert) {
+    updateCurrentUser({ experimental_sidebar_enabled: false });
+
+    await visit("/");
+    await click(".header-dropdown-toggle.current-user");
+
+    assert.ok(exists(".assigned.menu-link"));
+  });
+});
 
 acceptance("Discourse Assign | Sidebar when user can assign", function (needs) {
   needs.user({ experimental_sidebar_enabled: true, can_assign: true });


### PR DESCRIPTION
Assignments can already be accessed via sidebar.

### Before

![Screenshot from 2022-07-05 15-42-12](https://user-images.githubusercontent.com/4335742/177276153-dfed5746-d4bc-49ab-8b49-b0ded5b385a6.png)

### After

![Screenshot from 2022-07-05 15-42-19](https://user-images.githubusercontent.com/4335742/177276179-28522cfc-13ec-41f8-a2dd-1ec2201de639.png)
