### PR TITLE
Revert "UX: Don't display assign user menu glyph when sidebar is enabled (#356)"

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -649,11 +649,7 @@ function initialize(api) {
   });
 
   api.addUserMenuGlyph((widget) => {
-    if (
-      widget.currentUser &&
-      widget.currentUser.can_assign &&
-      !widget.currentUser.experimental_sidebar_enabled
-    ) {
+    if (widget.currentUser && widget.currentUser.can_assign) {
       const glyph = {
         label: "discourse_assign.assigned",
         className: "assigned",

--- a/test/javascripts/acceptance/assign-sidebar-test.js
+++ b/test/javascripts/acceptance/assign-sidebar-test.js
@@ -5,7 +5,6 @@ import {
   acceptance,
   exists,
   query,
-  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import AssignedTopics from "../fixtures/assigned-topics-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
@@ -25,27 +24,6 @@ acceptance(
     });
   }
 );
-
-acceptance("Discourse Assign | Sidebar | User Menu", function (needs) {
-  needs.user({ experimental_sidebar_enabled: true, can_assign: true });
-  needs.settings({ assign_enabled: true });
-
-  test("assign user menu is not displayed when user has enabled sidebar", async function (assert) {
-    await visit("/");
-    await click(".header-dropdown-toggle.current-user");
-
-    assert.ok(!exists(".assigned.menu-link"));
-  });
-
-  test("assign user menu glyph is displayed when user has disabled sidebar", async function (assert) {
-    updateCurrentUser({ experimental_sidebar_enabled: false });
-
-    await visit("/");
-    await click(".header-dropdown-toggle.current-user");
-
-    assert.ok(exists(".assigned.menu-link"));
-  });
-});
 
 acceptance("Discourse Assign | Sidebar when user can assign", function (needs) {
   needs.user({ experimental_sidebar_enabled: true, can_assign: true });


### PR DESCRIPTION
This reverts commit 479fcfb4115a258e1bdee9f81e02f4fbff82fc43.

Link in user menu dropdown is kept in favor of link in experimental
sidebar