### PR TITLE
FEATURE: Allow submitting the assign modal with ctrl+enter

### DIFF
--- a/assets/javascripts/discourse-assign/controllers/assign-user.js
+++ b/assets/javascripts/discourse-assign/controllers/assign-user.js
@@ -1,4 +1,5 @@
 import Controller, { inject as controller } from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { action } from "@ember/object";
 import { not, or } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
@@ -6,7 +7,7 @@ import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
-export default Controller.extend({
+export default Controller.extend(ModalFunctionality, {
   topicBulkActions: controller(),
   assignSuggestions: null,
   allowedGroups: null,
@@ -39,6 +40,13 @@ export default Controller.extend({
       type: "assign",
       username,
     });
+  },
+
+  @action
+  handleTextAreaKeydown(value, event) {
+    if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+      this.assign();
+    }
   },
 
   @action

--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -26,7 +26,7 @@
       {{/each}}
     </div>
     <label>{{i18n "discourse_assign.assign_modal.note_label"}}</label>
-    {{textarea value=model.note}}
+    {{textarea id="assign-modal-note" value=model.note key-down=(action "handleTextAreaKeydown")}}
   </div>
 {{/d-modal-body}}
 


### PR DESCRIPTION
This commit allows submitting the assign modal with
control/meta+enter when the textarea is focused.

The rest of the modal can already be submitted with
this key combo.