### PR TITLE
DEV: Add assignment ID to assign notification data

### DIFF
--- a/jobs/regular/assign_notification.rb
+++ b/jobs/regular/assign_notification.rb
@@ -8,6 +8,8 @@ module Jobs
       raise Discourse::InvalidParameters.new(:assigned_to_id) if args[:assigned_to_id].nil?
       raise Discourse::InvalidParameters.new(:assigned_to_type) if args[:assigned_to_type].nil?
       raise Discourse::InvalidParameters.new(:assigned_by_id) if args[:assigned_by_id].nil?
+      raise Discourse::InvalidParameters.new(:assignment_id) if args[:assignment_id].nil?
+
       if args[:skip_small_action_post].nil?
         raise Discourse::InvalidParameters.new(:skip_small_action_post)
       end
@@ -70,6 +72,7 @@ module Jobs
               ),
             display_username: assigned_to_user ? assigned_by.username : assigned_to.name,
             topic_title: topic.title,
+            assignment_id: args[:assignment_id],
           }.to_json,
         )
       end

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -241,7 +241,7 @@ class ::Assigner
 
     @target.assignment.update!(note: note, status: status)
 
-    queue_notification(assign_to, skip_small_action_post)
+    queue_notification(assign_to, skip_small_action_post, @target.assignment)
 
     assignment = @target.assignment
     publish_assignment(assignment, assign_to, note, status)
@@ -287,7 +287,7 @@ class ::Assigner
 
     first_post.publish_change_to_clients!(:revised, reload_topic: true)
 
-    queue_notification(assign_to, skip_small_action_post)
+    queue_notification(assign_to, skip_small_action_post, assignment)
 
     publish_assignment(assignment, assign_to, note, status)
 
@@ -440,7 +440,7 @@ class ::Assigner
 
   private
 
-  def queue_notification(assign_to, skip_small_action_post)
+  def queue_notification(assign_to, skip_small_action_post, assignment)
     Jobs.enqueue(
       :assign_notification,
       topic_id: topic.id,
@@ -449,6 +449,7 @@ class ::Assigner
       assigned_to_type: assign_to.is_a?(User) ? "User" : "Group",
       assigned_by_id: @assigned_by.id,
       skip_small_action_post: skip_small_action_post,
+      assignment_id: assignment.id,
     )
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -870,6 +870,7 @@ after_initialize do
           assigned_to_type: assignment.assigned_to_type,
           assigned_by_id: assignment.assigned_by_user_id,
           skip_small_action_post: true,
+          assignment_id: assignment.id,
         )
       end
   end

--- a/spec/jobs/regular/assign_notification_spec.rb
+++ b/spec/jobs/regular/assign_notification_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Jobs::AssignNotification do
                 assigned_to_type: "User",
                 assigned_by_id: user1.id,
                 skip_small_action_post: false,
+                assignment_id: 1093,
               },
             )
           end
@@ -54,6 +55,7 @@ RSpec.describe Jobs::AssignNotification do
               assigned_to_type: "User",
               assigned_by_id: user1.id,
               skip_small_action_post: false,
+              assignment_id: 9023,
             },
           )
         end
@@ -70,6 +72,7 @@ RSpec.describe Jobs::AssignNotification do
             message: "discourse_assign.assign_notification",
             display_username: user1.username,
             topic_title: topic.title,
+            assignment_id: 3194,
           }.to_json,
         )
         described_class.new.execute(
@@ -80,6 +83,7 @@ RSpec.describe Jobs::AssignNotification do
             assigned_to_type: "User",
             assigned_by_id: user1.id,
             skip_small_action_post: false,
+            assignment_id: 3194,
           },
         )
       end
@@ -110,6 +114,7 @@ RSpec.describe Jobs::AssignNotification do
                 assigned_to_type: "Group",
                 assigned_by_id: user1.id,
                 skip_small_action_post: false,
+                assignment_id: 7839,
               },
             )
           end
@@ -128,6 +133,7 @@ RSpec.describe Jobs::AssignNotification do
                 assigned_to_type: "Group",
                 assigned_by_id: user1.id,
                 skip_small_action_post: false,
+                assignment_id: 7763,
               },
             )
           end
@@ -146,6 +152,7 @@ RSpec.describe Jobs::AssignNotification do
                 assigned_to_type: "Group",
                 assigned_by_id: user1.id,
                 skip_small_action_post: false,
+                assignment_id: 8883,
               },
             )
           end
@@ -164,6 +171,7 @@ RSpec.describe Jobs::AssignNotification do
               message: "discourse_assign.assign_group_notification",
               display_username: group.name,
               topic_title: topic.title,
+              assignment_id: 9429,
             }.to_json,
           )
         end
@@ -176,6 +184,7 @@ RSpec.describe Jobs::AssignNotification do
             assigned_to_type: "Group",
             assigned_by_id: user1.id,
             skip_small_action_post: false,
+            assignment_id: 9429,
           },
         )
       end

--- a/spec/jobs/regular/unassign_notification_spec.rb
+++ b/spec/jobs/regular/unassign_notification_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Jobs::UnassignNotification do
             assigned_to_type: "User",
             assigned_by_id: user1.id,
             skip_small_action_post: false,
+            assignment_id: 4519,
           },
         )
 
@@ -82,6 +83,7 @@ RSpec.describe Jobs::UnassignNotification do
             assigned_to_type: "Group",
             assigned_by_id: user1.id,
             skip_small_action_post: false,
+            assignment_id: 9281,
           },
         )
 


### PR DESCRIPTION
This change makes it possible to associate an assign notification with the `assignments` record that creates the notification. It'll be needed for the assignments tab in the new experimental user menu, see https://github.com/discourse/discourse/pull/17379.