### PR TITLE
FIX: Check if assignment has same user and details

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -523,7 +523,15 @@ class ::Assigner
   end
 
   def post_same_assignee_and_details(assign_to, type, note, status)
-    @target.is_a?(Topic) &&
+    if @target.is_a?(Post)
+      @target.assignment&.assigned_to_id == assign_to.id &&
+      @target.assignment&.assigned_to_type == type && @target.assignment.active == true &&
+      @target.assignment&.note == note &&
+      (
+        @target.assignment&.status == status ||
+          @target.assignment&.status == Assignment.default_status && status.nil?
+      )
+    elsif @target.is_a?(Topic)
       Assignment
         .where(topic_id: topic.id, target_type: "Post", active: true)
         .any? do |assignment|
@@ -534,6 +542,7 @@ class ::Assigner
                 topic.assignment&.status == Assignment.default_status && status.nil?
             )
         end
+    end
   end
 
   def no_assignee_change?(assignee)

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -236,6 +236,16 @@ RSpec.describe Assigner do
         expect(assign[:reason]).to eq(:already_assigned)
       end
 
+      it "fails to assign when the assigned user and note is the same" do
+        assigner = described_class.new(post, moderator_2)
+        assigner.assign(moderator, note: "note me down")
+
+        assign = assigner.assign(moderator, note: "note me down")
+
+        expect(assign[:success]).to eq(false)
+        expect(assign[:reason]).to eq(:already_assigned)
+      end
+
       it "allows assign when the assigned user is same but note is different" do
         assigner = described_class.new(topic, moderator_2)
         assigner.assign(moderator, note: "note me down")


### PR DESCRIPTION
The check existed, but its implementation was incorrect and it did not
work when the target was a post.