### PR TITLE
FIX: Find better users for automatic assignment

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -175,46 +175,40 @@ module DiscourseAssign
     end
 
     def user_menu_assigns
-      assign_notifications = Notification.unread_type(
-        current_user,
-        Notification.types[:assigned],
-        user_menu_limit
-      )
+      assign_notifications =
+        Notification.unread_type(current_user, Notification.types[:assigned], user_menu_limit)
 
       if assign_notifications.size < user_menu_limit
         opts = {}
-        ignored_assignment_ids = assign_notifications.filter_map do |notification|
-          notification.data_hash[:assignment_id]
-        end
+        ignored_assignment_ids =
+          assign_notifications.filter_map { |notification| notification.data_hash[:assignment_id] }
         opts[:ignored_assignment_ids] = ignored_assignment_ids if ignored_assignment_ids.present?
 
-        assigns_list = TopicQuery.new(
-          current_user,
-          per_page: user_menu_limit - assign_notifications.size
-        ).list_messages_assigned(current_user, ignored_assignment_ids: ignored_assignment_ids)
+        assigns_list =
+          TopicQuery.new(
+            current_user,
+            per_page: user_menu_limit - assign_notifications.size,
+          ).list_messages_assigned(current_user, ignored_assignment_ids: ignored_assignment_ids)
       end
 
       if assign_notifications.present?
-        serialized_notifications = ActiveModel::ArraySerializer.new(
-          assign_notifications,
-          each_serializer: NotificationSerializer,
-          scope: guardian
-        )
+        serialized_notifications =
+          ActiveModel::ArraySerializer.new(
+            assign_notifications,
+            each_serializer: NotificationSerializer,
+            scope: guardian,
+          )
       end
 
       if assigns_list
-        serialized_assigns = serialize_data(
-          assigns_list,
-          TopicListSerializer,
-          scope: guardian,
-          root: false
-        )[:topics]
+        serialized_assigns =
+          serialize_data(assigns_list, TopicListSerializer, scope: guardian, root: false)[:topics]
       end
 
       render json: {
-        notifications: serialized_notifications || [],
-        topics: serialized_assigns || [],
-      }
+               notifications: serialized_notifications || [],
+               topics: serialized_assigns || [],
+             }
     end
 
     private

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -126,6 +126,9 @@ en:
             min_recently_assigned_days:
               label: Min recently assigned days
               description: Defaults to 14 days.
+            skip_new_users_for_days:
+              label: Skip new users for days
+              description: Defaults to 0 days (users can be assigned immediately after signing up).
             max_recently_assigned_days:
               label: Max recently assigned days
               description: First attempt to exclude users assigned in the last `n` days. If no user left, fallbacks to `min_recently_assigned_days`. Defaults to 180 days.

--- a/lib/random_assign_utils.rb
+++ b/lib/random_assign_utils.rb
@@ -38,7 +38,7 @@ class RandomAssignUtils
       raise_error(automation, "Group(#{group_id}) not found")
     end
 
-    allowed_assign_user_ids = User.assign_allowed.pluck(:id)
+    assignable_user_ids = User.assign_allowed.pluck(:id)
     users_on_holiday =
       Set.new(
         User.where(
@@ -51,10 +51,11 @@ class RandomAssignUtils
       group_users = group_users.where("users.created_at < ?", skip_new_users_for_days.to_i.days.ago)
     end
 
-    group_users_ids = group_users
-      .pluck("users.id")
-      .filter { |user_id| allowed_assign_user_ids.include?(user_id) }
-      .reject { |user_id| users_on_holiday.include?(user_id) }
+    group_users_ids =
+      group_users
+        .pluck("users.id")
+        .filter { |user_id| assignable_user_ids.include?(user_id) }
+        .reject { |user_id| users_on_holiday.include?(user_id) }
 
     if group_users_ids.empty?
       RandomAssignUtils.no_one!(topic_id, group.name)

--- a/lib/random_assign_utils.rb
+++ b/lib/random_assign_utils.rb
@@ -38,6 +38,7 @@ class RandomAssignUtils
       raise_error(automation, "Group(#{group_id}) not found")
     end
 
+    allowed_assign_user_ids = User.assign_allowed.pluck(:id)
     users_on_holiday =
       Set.new(
         User.where(
@@ -50,6 +51,7 @@ class RandomAssignUtils
         .group_users
         .joins(:user)
         .pluck("users.id")
+        .filter { |user_id| allowed_assign_user_ids.include?(user_id) }
         .reject { |user_id| users_on_holiday.include?(user_id) }
 
     if group_users_ids.empty?

--- a/plugin.rb
+++ b/plugin.rb
@@ -400,9 +400,7 @@ after_initialize do
     SQL
 
     where_args = { user_id: user.id }
-    if ignored_assignment_ids.present?
-      where_args[:ignored_assignment_ids] = ignored_assignment_ids
-    end
+    where_args[:ignored_assignment_ids] = ignored_assignment_ids if ignored_assignment_ids.present?
     list = list.where("topics.id IN (#{topic_ids_sql})", **where_args).includes(:allowed_users)
 
     create_list(:assigned, { unordered: true }, list)

--- a/plugin.rb
+++ b/plugin.rb
@@ -978,6 +978,7 @@ after_initialize do
       field :minimum_time_between_assignments, component: :text
       field :max_recently_assigned_days, component: :text
       field :min_recently_assigned_days, component: :text
+      field :skip_new_users_for_days, component: :text
       field :in_working_hours, component: :boolean
       field :post_template, component: :post
 

--- a/spec/lib/random_assign_utils_spec.rb
+++ b/spec/lib/random_assign_utils_spec.rb
@@ -78,6 +78,34 @@ describe RandomAssignUtils do
       end
     end
 
+    context "no users of group can be assigned because are not members of assign_allowed_on_groups groups" do
+      fab!(:topic_1) { Fabricate(:topic) }
+      fab!(:group_1) { Fabricate(:group) }
+      fab!(:user_1) { Fabricate(:user) }
+
+      before do
+        group_1.add(user_1)
+      end
+
+      it "creates post on the topic" do
+        described_class.automation_script!(
+          {},
+          {
+            "assignees_group" => {
+              "value" => group_1.id,
+            },
+            "assigned_topic" => {
+              "value" => topic_1.id,
+            },
+          },
+          automation,
+        )
+        expect(topic_1.posts.first.raw).to match(
+          "Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.",
+        )
+      end
+    end
+
     context "user can be assigned" do
       fab!(:group_1) { Fabricate(:group) }
       fab!(:user_1) { Fabricate(:user) }

--- a/spec/lib/random_assign_utils_spec.rb
+++ b/spec/lib/random_assign_utils_spec.rb
@@ -44,7 +44,7 @@ describe RandomAssignUtils do
           automation,
         )
         expect(topic_1.posts.first.raw).to match(
-          "Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.",
+          I18n.t("discourse_automation.scriptables.random_assign.no_one", group: group_1.name),
         )
       end
     end
@@ -73,19 +73,17 @@ describe RandomAssignUtils do
           automation,
         )
         expect(topic_1.posts.first.raw).to match(
-          "Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.",
+          I18n.t("discourse_automation.scriptables.random_assign.no_one", group: group_1.name),
         )
       end
     end
 
-    context "no users of group can be assigned because are not members of assign_allowed_on_groups groups" do
+    context "no users can be assigned because none are members of assign_allowed_on_groups groups" do
       fab!(:topic_1) { Fabricate(:topic) }
       fab!(:group_1) { Fabricate(:group) }
       fab!(:user_1) { Fabricate(:user) }
 
-      before do
-        group_1.add(user_1)
-      end
+      before { group_1.add(user_1) }
 
       it "creates post on the topic" do
         described_class.automation_script!(
@@ -101,7 +99,7 @@ describe RandomAssignUtils do
           automation,
         )
         expect(topic_1.posts.first.raw).to match(
-          "Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.",
+          I18n.t("discourse_automation.scriptables.random_assign.no_one", group: group_1.name),
         )
       end
     end
@@ -186,7 +184,7 @@ describe RandomAssignUtils do
           automation,
         )
         expect(topic_1.posts.first.raw).to match(
-          "Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.",
+          I18n.t("discourse_automation.scriptables.random_assign.no_one", group: group_1.name),
         )
       end
     end
@@ -307,7 +305,7 @@ describe RandomAssignUtils do
           automation,
         )
         expect(topic_1.posts.last.raw).to match(
-          "Attempted randomly assign a member of `@#{group_1.name}`, but no one was available.",
+          I18n.t("discourse_automation.scriptables.random_assign.no_one", group: group_1.name),
         )
       end
 


### PR DESCRIPTION
There were two problems with the way current automation script for automatic assignment works:

* it tried to assign users that were not allowed to be assigned because they were not part of groups that are allowed to use discourse-assign - fixed by skipping users that are not a part of assign_allowed_on_groups groups

* it assigned new users - fixed by adding a new user that can skip new users