### PR TITLE
FIX: Error bulk deleting posts when action post is already deleted

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -837,6 +837,7 @@ after_initialize do
     PostCustomField
       .where(name: "action_code_post_id", value: post.id)
       .find_each do |post_custom_field|
+        break if post_custom_field.post == nil
         if ![Post.types[:small_action], Post.types[:whisper]].include?(
              post_custom_field.post.post_type,
            )

--- a/plugin.rb
+++ b/plugin.rb
@@ -837,7 +837,7 @@ after_initialize do
     PostCustomField
       .where(name: "action_code_post_id", value: post.id)
       .find_each do |post_custom_field|
-        break if post_custom_field.post == nil
+        next if post_custom_field.post == nil
         if ![Post.types[:small_action], Post.types[:whisper]].include?(
              post_custom_field.post.post_type,
            )

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -560,6 +560,8 @@ RSpec.describe Assigner do
     context "post" do
       let(:post_2) { Fabricate(:post, topic: topic) }
       let(:assigner) { described_class.new(post_2, moderator) }
+      let(:post_3) { Fabricate(:post, topic: topic) }
+      let(:assigner_2) { described_class.new(post_3, moderator) }
 
       before do
         SiteSetting.unassign_on_close = true
@@ -595,6 +597,16 @@ RSpec.describe Assigner do
 
         PostDestroyer.new(moderator, post_2).destroy
         expect { small_action_post.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "deletes post successfully when small action is already deleted" do
+        assigner_2.assign(moderator)
+        small_action_post = PostCustomField.where(name: "action_code_post_id").first.post
+
+        PostDestroyer.new(moderator, small_action_post).destroy
+        PostDestroyer.new(moderator, post_3).destroy
+
+        expect(post_3).to be nil
       end
     end
   end

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -606,7 +606,8 @@ RSpec.describe Assigner do
         PostDestroyer.new(moderator, small_action_post).destroy
         PostDestroyer.new(moderator, post_3).destroy
 
-        expect(post_3).to be nil
+        expect(small_action_post.reload.deleted_at).to be_present
+        expect(post_3.reload.deleted_at).to be_present
       end
     end
   end


### PR DESCRIPTION
This PR fixes the issue that results when attempting to delete a post through bulk deletion when the post's corresponding post action is already deleted

Issue Preview:

https://user-images.githubusercontent.com/30090424/186519819-d39e02e6-f99f-4967-88be-b09144803ac2.mov

This PR resolves this fix by breaking out of the loop for deleting the corresponding post action, if the post action is already deleted.
