### PR TITLE
FIX: Count only active assignments when checking limits

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -213,7 +213,7 @@ class ::Assigner
       assign_to.is_a?(User) ? :forbidden_assign_to : :forbidden_group_assign_to
     when already_assigned?(assign_to, type, note, status)
       assign_to.is_a?(User) ? :already_assigned : :group_already_assigned
-    when Assignment.where(topic: topic).count >= ASSIGNMENTS_PER_TOPIC_LIMIT
+    when Assignment.where(topic: topic, active: true).count >= ASSIGNMENTS_PER_TOPIC_LIMIT
       :too_many_assigns_for_topic
     when !can_assign_to?(assign_to)
       :too_many_assigns


### PR DESCRIPTION
Only 5 assignments can exist simultaneously for a topic or its post.
The code that counted the assignments did not ignore the inactive
assignments which made the limit check more strict than it should have
been.