### PR TITLE
UX: Add title for the assign tab in the user menu

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -151,3 +151,8 @@ en:
             other: "Are you sure? You have %{count} unread assign notifications."
     user_menu:
       view_all_assigned: "view all assigned"
+      tabs:
+        assign_list: "Assign list"
+        assign_list_with_unread:
+          one: "Assign list - %{count} unread assignment"
+          other: "Assign list - %{count} unread assignments"


### PR DESCRIPTION
As of https://github.com/discourse/discourse/commit/496f910f03dfbc0a8021561fa7795a68894ef0e4, core automatically adds title to user menu tabs if an i18n string exists at the key `user_menu.tabs.${tab_id}`. This PR adds a string in the right place so core picks it up and uses it for the assign tab.