### PR TITLE
FEATURE: show user status when assigning topics and posts

### DIFF
--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -6,6 +6,7 @@
       value=assigneeName
       onChange=(action "assignUsername")
       autofocus="autofocus"
+      showUserStatus=true
       options=(hash
         mobilePlacementStrategy="absolute"
         filterPlaceholder=placeholderKey


### PR DESCRIPTION
This will start working after merging https://github.com/discourse/discourse/pull/18367.

<img width="250" alt="Screenshot 2022-09-27 at 00 33 50" src="https://user-images.githubusercontent.com/1274517/192379603-4dc05a1f-9aef-41c9-9413-4582a603d3af.png">
