### PR TITLE
DEV: Persist records to DB in tests

### DIFF
--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Assigner do
 
       it "doesn't assign if the user has too many assigned topics" do
         SiteSetting.max_assigned_topics = 1
-        another_post = Fabricate.build(:post)
+        another_post = Fabricate(:post)
         assigner.assign(moderator)
 
         second_assign = described_class.new(another_post.topic, moderator_2).assign(moderator)


### PR DESCRIPTION
There is almost no reason for us to use `Fabricate.build` which does not persist the record to the database and is not what we encounter in production.