### PR TITLE
FEATURE: Cleanup notifications when reassigning

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -271,6 +271,15 @@ class ::Assigner
 
     skip_small_action_post = skip_small_action_post || no_assignee_change?(assign_to)
 
+    if topic.assignment.present?
+      Jobs.enqueue(
+        :unassign_notification,
+        topic_id: topic.id,
+        assigned_to_id: topic.assignment.assigned_to_id,
+        assigned_to_type: topic.assignment.assigned_to_type,
+      )
+    end
+
     @target.assignment&.destroy!
 
     assignment =

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe Assigner do
       )
     end
 
+    it "deletes notification for original assignee when reassigning" do
+      Jobs.run_immediately!
+
+      expect {
+        described_class.new(topic, admin).assign(moderator)
+      }.to change { moderator.notifications.count }.by(1)
+
+      expect {
+        described_class.new(topic, admin).assign(moderator_2)
+      }.to change { moderator.notifications.count }.by(-1)
+      .and change { moderator_2.notifications.count }.by(1)
+    end
+
     it "can assign with note" do
       assigner.assign(moderator, note: "tomtom best mom")
 


### PR DESCRIPTION
If a topic is initially assigned to user A then reassigned to user B, this change will make it so that notifications sent to user A are removed. This matches the plugin's behaviour when unassigning a topic.