### PR TITLE
UX: Rephrase notification message

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -39,7 +39,7 @@ en:
     flag_assigned: "Sorry, that flag's topic is assigned to another user"
     flag_unclaimed: "You must claim that topic before acting on the flag"
     topic_assigned_excerpt: "assigned you the topic '%{title}'"
-    topic_group_assigned_excerpt: "assigned to %{group} the topic '%{title}'"
+    topic_group_assigned_excerpt: "assigned the topic '%{title}' to @%{group}"
     reminders_frequency:
       never: "never"
       daily: "daily"

--- a/spec/jobs/regular/assign_notification_spec.rb
+++ b/spec/jobs/regular/assign_notification_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Jobs::AssignNotification do
           end
 
         expect(messages.length).to eq(1)
-        expect(messages.first.data[:excerpt]).to eq("assigned you the topic 'Basic topic title'")
+        expect(messages.first.data[:excerpt]).to eq(
+          I18n.t("discourse_assign.topic_assigned_excerpt", title: topic.title),
+        )
       end
 
       it "should publish the right message when private message" do
@@ -120,7 +122,11 @@ RSpec.describe Jobs::AssignNotification do
           end
         expect(messages.length).to eq(1)
         expect(messages.first.data[:excerpt]).to eq(
-          "assigned to Developers the topic 'Basic topic title'",
+          I18n.t(
+            "discourse_assign.topic_group_assigned_excerpt",
+            title: topic.title,
+            group: group.name,
+          ),
         )
 
         messages =
@@ -139,7 +145,11 @@ RSpec.describe Jobs::AssignNotification do
           end
         expect(messages.length).to eq(1)
         expect(messages.first.data[:excerpt]).to eq(
-          "assigned to Developers the topic 'Basic topic title'",
+          I18n.t(
+            "discourse_assign.topic_group_assigned_excerpt",
+            title: topic.title,
+            group: group.name,
+          ),
         )
 
         messages =


### PR DESCRIPTION
The original message is quite hard to read and multiple translators suggested the rephrase.