### PR TITLE
DEV: Change flaky spec to provide more information when it fails

### DIFF
--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -110,14 +110,17 @@ describe "integration tests" do
     end
 
     it "assigns topic" do
-      DiscourseEvent.trigger(:assign_topic, topic, user1, admin)
-      expect(topic.assignment.assigned_to_id).to eq(user1.id)
+      expect do DiscourseEvent.trigger(:assign_topic, topic, user1, admin) end.to change {
+        Assignment.where(topic: topic).pluck_first(:assigned_to_id)
+      }.from(nil).to(user1.id)
 
-      DiscourseEvent.trigger(:assign_topic, topic, user2, admin)
-      expect(topic.assignment.assigned_to_id).to eq(user1.id)
+      expect do DiscourseEvent.trigger(:assign_topic, topic, user2, admin) end.to_not change {
+        Assignment.where(topic: topic).pluck_first(:assigned_to_id)
+      }.from(user1.id)
 
-      DiscourseEvent.trigger(:assign_topic, topic, user2, admin, true)
-      expect(topic.assignment.assigned_to_id).to eq(user2.id)
+      expect do DiscourseEvent.trigger(:assign_topic, topic, user2, admin, true) end.to change {
+        Assignment.where(topic: topic).pluck_first(:assigned_to_id)
+      }.from(user1.id).to(user2.id)
     end
 
     it "triggers a webhook for assigned and unassigned" do


### PR DESCRIPTION
This spec has been detected to be flaky by
https://github.com/discourse/flaky-tests-detective which we run
internally. However, I could not reproduce the flakiness after multiple
attempts so I rewrote the assertions such that we set up the
expectations of what `Assignment#assigned_to_id` should be before and
after the triggering of the DiscourseEvent.