### PR TITLE
FIX: Build correct assign tag links when using subfolders

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -641,7 +641,7 @@ function initialize(api) {
           const tagName = params.tagName || "a";
           const href =
             tagName === "a"
-              ? `href="${assignedPath}" data-auto-route="true"`
+              ? `href="${getURL(assignedPath)}" data-auto-route="true"`
               : "";
           return `<${tagName} class="assigned-to discourse-tag simple" ${href}>
         ${icon}


### PR DESCRIPTION
[Meta topic](https://meta.discourse.org/t/404-error-page-is-opened-after-clicking-on-assignee-tag-under-the-title/249333).

### What's the problem?

The tag links added to the topic header extras aren't aware of subfolder usage, e.g. the topic URL would be generated as a vanilla `/t/:id` URL. The same applies to post assignments.

### How does this fix it?

This change fixes that by passing the link URL through the [`getURL`](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse-common/addon/lib/get-url.js#L6) helper.

### What about tests?

I searched around for tests that simulate subfolders, but couldn't find any. If anyone know these exist and can point me to them, that'd be great.