### PR TITLE
FIX: Broken posts when assigning a closed topic

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: ${{ matrix.build_type }}
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
+    container: discourse/discourse_test:slim${{ startsWith(matrix.build_type, 'frontend') && '-browsers' || '' }}
     timeout-minutes: 30
 
     env:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build_type: ["backend", "frontend", "system"]
+        build_type: ["backend", "frontend"]
 
     steps:
       - uses: actions/checkout@v3
@@ -149,18 +149,3 @@ jobs:
         if: matrix.build_type == 'frontend' && steps.check_qunit.outputs.files_exist == 'true'
         run: QUNIT_EMBER_CLI=1 bundle exec rake plugin:qunit['${{ github.event.repository.name }}','1200000']
         timeout-minutes: 10
-
-      - name: Ember Build for System Tests
-        if: matrix.build_type == 'system'
-        run: bin/ember-cli --build
-
-      - name: Plugin System Tests
-        if: matrix.build_type == 'system'
-        run: LOAD_PLUGINS=1 bin/system_rspec plugins/*/spec/system
-
-      - name: Upload failed system test screenshots
-        uses: actions/upload-artifact@v3
-        if: matrix.build_type == 'system' && failure()
-        with:
-          name: failed-system-test-screenshots
-          path: tmp/screenshots/*.png

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: ${{ matrix.build_type }}
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:slim${{ startsWith(matrix.build_type, 'frontend') && '-browsers' || '' }}
+    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
     timeout-minutes: 30
 
     env:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build_type: ["backend", "frontend"]
+        build_type: ["backend", "frontend", "system"]
 
     steps:
       - uses: actions/checkout@v3
@@ -149,3 +149,18 @@ jobs:
         if: matrix.build_type == 'frontend' && steps.check_qunit.outputs.files_exist == 'true'
         run: QUNIT_EMBER_CLI=1 bundle exec rake plugin:qunit['${{ github.event.repository.name }}','1200000']
         timeout-minutes: 10
+
+      - name: Ember Build for System Tests
+        if: matrix.build_type == 'system'
+        run: bin/ember-cli --build
+
+      - name: Plugin System Tests
+        if: matrix.build_type == 'system'
+        run: LOAD_PLUGINS=1 bin/system_rspec plugins/*/spec/system
+
+      - name: Upload failed system test screenshots
+        uses: actions/upload-artifact@v3
+        if: matrix.build_type == 'system' && failure()
+        with:
+          name: failed-system-test-screenshots
+          path: tmp/screenshots/*.png

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -811,6 +811,11 @@ function initialize(api) {
             });
             this.appEvents.trigger("post-stream:refresh", { id: data.post_id });
           }
+          if (topic.closed) {
+            this.appEvents.trigger("post-stream:refresh", {
+              id: topic.postStream.posts[0].id,
+            });
+          }
         }
         this.appEvents.trigger("header:update-topic", topic);
       });

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -261,7 +261,7 @@ class ::Assigner
       forbidden_reasons(assign_to: assign_to, type: assigned_to_type, note: note, status: status)
     return { success: false, reason: forbidden_reason } if forbidden_reason
 
-    if no_assignee_change?(assign_to)
+    if no_assignee_change?(assign_to) && details_change?(note, status)
       return update_details(assign_to, note, status, skip_small_action_post: skip_small_action_post)
     end
 
@@ -534,6 +534,10 @@ class ::Assigner
 
   def no_assignee_change?(assignee)
     @target.assignment&.assigned_to_id == assignee.id
+  end
+
+  def details_change?(note, status)
+    note.present? || @target.assignment&.status != status
   end
 
   def assignment_eq?(assignment, assign_to, type, note, status)

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+describe "Assign | Assigning topics", type: :system, js: true do
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:assign_modal) { PageObjects::Modals::Assign.new }
+  fab!(:staff_user) { Fabricate(:user, groups: [Group[:staff]]) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+
+  before do
+    SiteSetting.assign_enabled = true
+    sign_in(admin)
+  end
+
+  describe "with open topic" do
+    it "can assign and unassign" do
+      visit "/t/#{topic.id}"
+
+      topic_page.click_assign_topic
+      assign_modal.set_assignee(staff_user)
+      assign_modal.confirm
+
+      expect(find("#post_2")).to have_content("Assigned")
+      expect(find("#topic .assigned-to")).to have_content(staff_user.username)
+
+      topic_page.click_unassign_topic
+
+      expect(find("#post_3")).to have_content("Unassigned")
+      expect(page).not_to have_css("#topic .assigned-to")
+    end
+
+    context "when unassign_on_close is set to true" do
+      before { SiteSetting.unassign_on_close = true }
+
+      it "topic gets unassigned on close" do
+        visit "/t/#{topic.id}"
+
+        topic_page.click_assign_topic
+        assign_modal.set_assignee(staff_user)
+        assign_modal.confirm
+
+        expect(find("#post_2")).to have_content("Assigned")
+
+        find(".topic-footer-main-buttons .toggle-admin-menu").click
+        find(".topic-admin-close").click
+
+        expect(find("#post_3")).to have_content("Closed")
+        expect(page).not_to have_css("#post_4")
+        expect(page).not_to have_css("#topic .assigned-to")
+      end
+
+      it "can assign the previous assignee" do
+        visit "/t/#{topic.id}"
+
+        topic_page.click_assign_topic
+        assign_modal.set_assignee(staff_user)
+        assign_modal.confirm
+
+        expect(find("#post_2")).to have_content("Assigned")
+
+        find(".topic-footer-main-buttons .toggle-admin-menu").click
+        find(".topic-admin-close").click
+
+        expect(find("#post_3")).to have_content("Closed")
+        expect(page).not_to have_css("#post_4")
+        expect(page).not_to have_css("#topic .assigned-to")
+
+        topic_page.click_assign_topic
+        assign_modal.set_assignee(staff_user)
+        assign_modal.confirm
+
+        expect(page).not_to have_css("#post_4")
+        expect(find("#topic .assigned-to")).to have_content(staff_user.username)
+      end
+
+      context "when reassign_on_open is set to true" do
+        before { SiteSetting.reassign_on_open = true }
+
+        it "topic gets reassigned on open" do
+          visit "/t/#{topic.id}"
+
+          topic_page.click_assign_topic
+          assign_modal.set_assignee(staff_user)
+          assign_modal.confirm
+
+          expect(find("#post_2")).to have_content("Assigned")
+
+          find(".topic-footer-main-buttons .toggle-admin-menu").click
+          find(".topic-admin-close").click
+
+          expect(find("#post_3")).to have_content("Closed")
+          expect(page).not_to have_css("#post_4")
+          expect(page).not_to have_css("#topic .assigned-to")
+
+          find(".topic-footer-main-buttons .toggle-admin-menu").click
+          find(".topic-admin-open").click
+
+          expect(page).not_to have_css("#post_4")
+          expect(find("#topic .assigned-to")).to have_content(staff_user.username)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -33,7 +33,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
     context "when unassign_on_close is set to true" do
       before { SiteSetting.unassign_on_close = true }
 
-      it "topic gets unassigned on close" do
+      it "unassigns the topic on close" do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -21,13 +21,13 @@ describe "Assign | Assigning topics", type: :system, js: true do
       assign_modal.set_assignee(staff_user)
       assign_modal.confirm
 
-      expect(find("#post_2")).to have_content("Assigned")
+      expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
       expect(find("#topic .assigned-to")).to have_content(staff_user.username)
 
       topic_page.click_unassign_topic
 
-      expect(find("#post_3")).to have_content("Unassigned")
-      expect(page).not_to have_css("#topic .assigned-to")
+      expect(topic_page).to have_assignment_action(3, "unassigned", staff_user)
+      expect(page).to have_no_css("#topic .assigned-to")
     end
 
     context "when unassign_on_close is set to true" do
@@ -40,14 +40,16 @@ describe "Assign | Assigning topics", type: :system, js: true do
         assign_modal.set_assignee(staff_user)
         assign_modal.confirm
 
-        expect(find("#post_2")).to have_content("Assigned")
+        expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
 
         find(".topic-footer-main-buttons .toggle-admin-menu").click
         find(".topic-admin-close").click
 
-        expect(find("#post_3")).to have_content("Closed")
-        expect(page).not_to have_css("#post_4")
-        expect(page).not_to have_css("#topic .assigned-to")
+        expect(find("#post_3")).to have_content(
+          I18n.t("js.action_codes.closed.enabled", when: "just now"),
+        )
+        expect(page).to have_no_css("#post_4")
+        expect(page).to have_no_css("#topic .assigned-to")
       end
 
       it "can assign the previous assignee" do
@@ -57,20 +59,22 @@ describe "Assign | Assigning topics", type: :system, js: true do
         assign_modal.set_assignee(staff_user)
         assign_modal.confirm
 
-        expect(find("#post_2")).to have_content("Assigned")
+        expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
 
         find(".topic-footer-main-buttons .toggle-admin-menu").click
         find(".topic-admin-close").click
 
-        expect(find("#post_3")).to have_content("Closed")
-        expect(page).not_to have_css("#post_4")
-        expect(page).not_to have_css("#topic .assigned-to")
+        expect(find("#post_3")).to have_content(
+          I18n.t("js.action_codes.closed.enabled", when: "just now"),
+        )
+        expect(page).to have_no_css("#post_4")
+        expect(page).to have_no_css("#topic .assigned-to")
 
         topic_page.click_assign_topic
         assign_modal.set_assignee(staff_user)
         assign_modal.confirm
 
-        expect(page).not_to have_css("#post_4")
+        expect(page).to have_no_css("#post_4")
         expect(find("#topic .assigned-to")).to have_content(staff_user.username)
       end
 
@@ -84,19 +88,24 @@ describe "Assign | Assigning topics", type: :system, js: true do
           assign_modal.set_assignee(staff_user)
           assign_modal.confirm
 
-          expect(find("#post_2")).to have_content("Assigned")
+          expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
 
           find(".topic-footer-main-buttons .toggle-admin-menu").click
           find(".topic-admin-close").click
 
-          expect(find("#post_3")).to have_content("Closed")
-          expect(page).not_to have_css("#post_4")
-          expect(page).not_to have_css("#topic .assigned-to")
+          expect(find("#post_3")).to have_content(
+            I18n.t("js.action_codes.closed.enabled", when: "just now"),
+          )
+          expect(page).to have_no_css("#post_4")
+          expect(page).to have_no_css("#topic .assigned-to")
 
           find(".topic-footer-main-buttons .toggle-admin-menu").click
           find(".topic-admin-open").click
 
-          expect(page).not_to have_css("#post_4")
+          expect(find("#post_4")).to have_content(
+            I18n.t("js.action_codes.closed.disabled", when: "just now"),
+          )
+          expect(page).to have_no_css("#post_5")
           expect(find("#topic .assigned-to")).to have_content(staff_user.username)
         end
       end

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -81,7 +81,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
       context "when reassign_on_open is set to true" do
         before { SiteSetting.reassign_on_open = true }
 
-        it "topic gets reassigned on open" do
+        it "reassigns the topic on open" do
           visit "/t/#{topic.id}"
 
           topic_page.click_assign_topic

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -18,15 +18,15 @@ describe "Assign | Assigning topics", type: :system, js: true do
       visit "/t/#{topic.id}"
 
       topic_page.click_assign_topic
-      assign_modal.set_assignee(staff_user)
+      assign_modal.assignee = staff_user
       assign_modal.confirm
 
-      expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
+      expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
       expect(find("#topic .assigned-to")).to have_content(staff_user.username)
 
       topic_page.click_unassign_topic
 
-      expect(topic_page).to have_assignment_action(3, "unassigned", staff_user)
+      expect(topic_page).to have_unassigned(user: staff_user, at_post: 3)
       expect(page).to have_no_css("#topic .assigned-to")
     end
 
@@ -37,10 +37,10 @@ describe "Assign | Assigning topics", type: :system, js: true do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic
-        assign_modal.set_assignee(staff_user)
+        assign_modal.assignee = staff_user
         assign_modal.confirm
 
-        expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
+        expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
         find(".topic-footer-main-buttons .toggle-admin-menu").click
         find(".topic-admin-close").click
@@ -56,10 +56,10 @@ describe "Assign | Assigning topics", type: :system, js: true do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic
-        assign_modal.set_assignee(staff_user)
+        assign_modal.assignee = staff_user
         assign_modal.confirm
 
-        expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
+        expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
         find(".topic-footer-main-buttons .toggle-admin-menu").click
         find(".topic-admin-close").click
@@ -71,7 +71,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
         expect(page).to have_no_css("#topic .assigned-to")
 
         topic_page.click_assign_topic
-        assign_modal.set_assignee(staff_user)
+        assign_modal.assignee = staff_user
         assign_modal.confirm
 
         expect(page).to have_no_css("#post_4")
@@ -85,10 +85,10 @@ describe "Assign | Assigning topics", type: :system, js: true do
           visit "/t/#{topic.id}"
 
           topic_page.click_assign_topic
-          assign_modal.set_assignee(staff_user)
+          assign_modal.assignee = staff_user
           assign_modal.confirm
 
-          expect(topic_page).to have_assignment_action(2, "assigned", staff_user)
+          expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
           find(".topic-footer-main-buttons .toggle-admin-menu").click
           find(".topic-admin-close").click

--- a/spec/system/page_objects/modals/assign.rb
+++ b/spec/system/page_objects/modals/assign.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class Assign < PageObjects::Modals::Base
+      def set_assignee(assignee)
+        assignee = assignee.is_a?(Group) ? assignee.name : assignee.username
+        find(".control-group .multi-select").click
+        find(".control-group input").fill_in(with: assignee)
+        find("li[data-value='#{assignee}']").click
+      end
+
+      def fill_status(status)
+        find("#assign-status").click
+        find("[data-value='#{status}']").click
+      end
+
+      def fill_note(note)
+        find("#assign-modal-note").fill_in(with: note)
+      end
+
+      def confirm
+        find(".modal-footer .btn-primary").click
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/modals/assign.rb
+++ b/spec/system/page_objects/modals/assign.rb
@@ -3,19 +3,19 @@
 module PageObjects
   module Modals
     class Assign < PageObjects::Modals::Base
-      def set_assignee(assignee)
+      def assignee=(assignee)
         assignee = assignee.is_a?(Group) ? assignee.name : assignee.username
         find(".control-group .multi-select").click
         find(".control-group input").fill_in(with: assignee)
         find("li[data-value='#{assignee}']").click
       end
 
-      def fill_status(status)
+      def status=(status)
         find("#assign-status").click
         find("[data-value='#{status}']").click
       end
 
-      def fill_note(note)
+      def note=(note)
         find("#assign-modal-note").fill_in(with: note)
       end
 

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Topic < PageObjects::Pages::Base
+      def click_assign_topic
+        find("#topic-footer-button-assign").click
+      end
+
+      def click_unassign_topic
+        find("#topic-footer-dropdown-reassign").click
+        find("[data-value='unassign']").click
+      end
+
+      def click_edit_topic_assignment
+        find("#topic-footer-dropdown-reassign").click
+        find("[data-value='reassign']").click
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -16,6 +16,13 @@ module PageObjects
         find("#topic-footer-dropdown-reassign").click
         find("[data-value='reassign']").click
       end
+
+      def has_assignment_action?(post_num, action, assignee)
+        assignee = assignee.is_a?(Group) ? assignee.name : assignee.username
+        find("#post_#{post_num}").has_content?(
+          I18n.t("js.action_codes.#{action}", who: "@#{assignee}", when: "just now"),
+        )
+      end
     end
   end
 end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -17,10 +17,19 @@ module PageObjects
         find("[data-value='reassign']").click
       end
 
-      def has_assignment_action?(post_num, action, assignee)
-        assignee = assignee.is_a?(Group) ? assignee.name : assignee.username
-        find("#post_#{post_num}").has_content?(
-          I18n.t("js.action_codes.#{action}", who: "@#{assignee}", when: "just now"),
+      def has_assigned?(args)
+        has_assignment_action?(action: "assigned", **args)
+      end
+
+      def has_unassigned?(args)
+        has_assignment_action?(action: "unassigned", **args)
+      end
+
+      def has_assignment_action?(args)
+        assignee = args[:group]&.name || args[:user]&.username
+        container = args[:at_post] ? find("#post_#{args[:at_post]}") : page
+        container.has_content?(
+          I18n.t("js.action_codes.#{args[:action]}", who: "@#{assignee}", when: "just now"),
         )
       end
     end


### PR DESCRIPTION
1. Assign a topic to someone
2. Close the topic with the setting unassign_on_close enabled
3. Assign the topic to the same user as before

This caused small broken or empty posts to be displayed.