### PR TITLE
FIX: Deactivate active assignments attached to deleted targets

### DIFF
--- a/db/migrate/20230113025043_deactivate_assignments_to_deleted_targets.rb
+++ b/db/migrate/20230113025043_deactivate_assignments_to_deleted_targets.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class DeactivateAssignmentsToDeletedTargets < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE assignments
+      SET active = false
+      FROM posts
+      WHERE posts.id = assignments.target_id
+        AND assignments.target_type = 'Post'
+        AND posts.deleted_at IS NOT NULL
+        AND assignments.active = true
+    SQL
+
+    execute <<~SQL
+      UPDATE assignments
+      SET active = false
+      FROM topics
+      WHERE topics.id = assignments.target_id
+        AND assignments.target_type = 'Topic'
+        AND topics.deleted_at IS NOT NULL
+        AND assignments.active = true
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Before the implementation of the `post_destroyed` event handler in the plugin, soft deleting assigned posts/topics did not deactivate the assignment.
This left sites which assigned and deleted posts/topics before the introduction of the event handler with 'orphaned' assignments in the UI.

This change deactivates these orphaned assignments.