### PR TITLE
FIX: System tests failing due to assignee chooser

### DIFF
--- a/spec/system/page_objects/modals/assign.rb
+++ b/spec/system/page_objects/modals/assign.rb
@@ -5,7 +5,6 @@ module PageObjects
     class Assign < PageObjects::Modals::Base
       def assignee=(assignee)
         assignee = assignee.is_a?(Group) ? assignee.name : assignee.username
-        find(".control-group .multi-select").click
         find(".control-group input").fill_in(with: assignee)
         find("li[data-value='#{assignee}']").click
       end


### PR DESCRIPTION
Since now the assignee chooser opens automatically, clicking on it was causing it to close