### PR TITLE
FIX: Do not expand if assignee username present

### DIFF
--- a/assets/javascripts/discourse/templates/modal/assign-user.hbs
+++ b/assets/javascripts/discourse/templates/modal/assign-user.hbs
@@ -20,7 +20,7 @@
           maximum=1
           autofocus=autofocus
           tabindex=1
-          expandedOnInsert=true
+          expandedOnInsert=(not assigneeName)
         )
       }}
       {{#if this.assigneeError}}


### PR DESCRIPTION
This does not work as expected and can lead to a worse user experience.