### PR TITLE
UX: fix list being limited by modal size

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -71,6 +71,10 @@
     width: 400px;
   }
 
+  .assign.modal-body {
+    overflow-y: unset;
+  }
+
   label {
     font-weight: bold;
 
@@ -104,6 +108,7 @@
       display: flex;
       align-items: flex-end;
       line-height: var(--line-height-small);
+      overflow: hidden;
     }
 
     .name {


### PR DESCRIPTION
This cut-off
<img width="440" alt="image" src="https://user-images.githubusercontent.com/101828855/214286045-ba974676-1d9b-4dce-9840-a787e89d22a2.png">

to be able to extend beyond the modal box
<img width="425" alt="image" src="https://user-images.githubusercontent.com/101828855/214286271-89094936-9aa6-4624-b171-31f34f1b70aa.png">
