### PR TITLE
FIX: n+1 in search result

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -306,10 +306,9 @@ after_initialize do
             topic_assignments&.find { |assignment| assignment.target_type == "Topic" }
           indirect_assignments =
             topic_assignments&.select { |assignment| assignment.target_type == "Post" }
-          if direct_assignment
-            assigned_to = direct_assignment.assigned_to
-            post.topic.preload_assigned_to(assigned_to)
-          end
+
+          post.topic.preload_assigned_to(direct_assignment&.assigned_to)
+          post.topic.preload_indirectly_assigned_to(nil)
           if indirect_assignments.present?
             indirect_assignment_map =
               indirect_assignments.reduce({}) do |acc, assignment|

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -38,7 +38,7 @@ describe SearchController do
     expect(assigned_to_group_data["assign_path"]).to eq("/g/#{group.name}/assigned/everyone")
   end
 
-  it "does not N+1 queries when search" do
+  it "does not result in N+1 queries when search returns multiple results" do
     SearchIndexer.enable
     SiteSetting.assigns_public = true
     post = Fabricate(:post, topic: Fabricate(:topic, title: "this is an awesome title"))

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -42,25 +42,16 @@ describe SearchController do
     SearchIndexer.enable
     SiteSetting.assigns_public = true
     post = Fabricate(:post, topic: Fabricate(:topic, title: "this is an awesome title"))
-    post_2 = Fabricate(:post, topic: Fabricate(:topic, title: "this is an awesome title 2"))
-
-    topic = Fabricate(:topic, title: "this is an awesome title 3")
-    post_3 = Fabricate(:post, topic: topic)
 
     get "/search/query.json", params: { term: "awesome" }
 
-    Assigner.new(post.topic, admin).assign(group)
-    Assigner.new(post_2.topic, admin).assign(group)
-    Assigner.new(post_3.topic, admin).assign(group)
     initial_sql_queries_count =
       track_sql_queries { get "/search/query.json", params: { term: "awesome" } }.count
 
-    Assigner.new(post.topic, admin).unassign
-    Assigner.new(post_2.topic, admin).unassign
-    Assigner.new(post_3.topic, admin).unassign
+    Fabricate(:post, topic: Fabricate(:topic, title: "this is an awesome title 2"))
+    Fabricate(:post, topic: Fabricate(:topic, title: "this is an awesome title 3"))
     new_sql_queries_count =
       track_sql_queries { get "/search/query.json", params: { term: "awesome" } }.count
-
-    expect(new_sql_queries_count).to be <= initial_sql_queries_count
+    expect(new_sql_queries_count).to eq(initial_sql_queries_count)
   end
 end


### PR DESCRIPTION
When assignment data is preloaded for search results, cache variable should be set when topic is assigned but also when topic is not assigned to avoid additional queries.