### PR TITLE
UX: remove whitespace in assign tag

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -649,9 +649,9 @@ function initialize(api) {
             tagName === "a"
               ? `href="${getURL(assignedPath)}" data-auto-route="true"`
               : "";
-          return `<${tagName} class="assigned-to discourse-tag simple" ${href}>
-                  ${icon}<span title="${escapeExpression(note)}">${name}</span>
-                  </${tagName}>`;
+          return `<${tagName} class="assigned-to discourse-tag simple" ${href}>${icon}<span title="${escapeExpression(
+            note
+          )}">${name}</span></${tagName}>`;
         })
         .join("");
     }

--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -650,9 +650,8 @@ function initialize(api) {
               ? `href="${getURL(assignedPath)}" data-auto-route="true"`
               : "";
           return `<${tagName} class="assigned-to discourse-tag simple" ${href}>
-        ${icon}
-        <span title="${escapeExpression(note)}">${name}</span>
-      </${tagName}>`;
+                  ${icon}<span title="${escapeExpression(note)}">${name}</span>
+                  </${tagName}>`;
         })
         .join("");
     }


### PR DESCRIPTION
We already handle the space between icons and text with margins. 

Before:
![Screenshot 2023-02-07 at 3 22 18 PM](https://user-images.githubusercontent.com/1681963/217356555-653007c0-3cdc-47f7-bd21-bd135195eb28.png)


After:
![Screenshot 2023-02-07 at 3 22 27 PM](https://user-images.githubusercontent.com/1681963/217356564-2baecdfc-745f-40da-86e8-bf7fb435f93a.png)
