### PR TITLE
DEV: Make assigned-topic-list a real component

### DIFF
--- a/assets/javascripts/discourse/components/assigned-topic-list.js
+++ b/assets/javascripts/discourse/components/assigned-topic-list.js
@@ -1,3 +1,3 @@
 import TopicList from "discourse/components/topic-list";
 
-export default TopicList;
+export default class AssignedTopicList extends TopicList {}


### PR DESCRIPTION
Re-exporting the TopicList component as-is leads to unexpected behavior when colocating templates because `AssignedTopicList` === `TopicList`. Extending it gives the component its own identity.