### PR TITLE
DEV: Make basic-assigned-topic-list a real component

### DIFF
--- a/assets/javascripts/discourse/components/basic-assigned-topic-list.js
+++ b/assets/javascripts/discourse/components/basic-assigned-topic-list.js
@@ -1,3 +1,3 @@
 import BasicTopicList from "discourse/components/basic-topic-list";
 
-export default BasicTopicList;
+export default class BasicAssignedTopicList extends BasicTopicList {}


### PR DESCRIPTION
Re-exporting the BasicTopicList component as-is leads to unexpected behavior when colocating templates because `BasicAssignedTopicList` === `BasicTopicList`. Extending it gives the component its own identity.

Similar to 8ba7b0727a3ad8673b0ff467c2925ab7ef8b4524