### PR TITLE
Prevent trimming of tall letters in the user selector

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -107,7 +107,6 @@
     .user-wrapper {
       display: flex;
       align-items: flex-end;
-      line-height: var(--line-height-small);
       overflow: hidden;
     }
 


### PR DESCRIPTION
This fix prevents some letters from being cut, as the issue shown here:

![image](https://user-images.githubusercontent.com/5654300/218792811-6d55fb30-4f58-40f4-8a95-98526e9b75c9.png)
