### PR TITLE
UX: fix status alignment after core change

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -106,7 +106,7 @@
 
     .user-wrapper {
       display: flex;
-      align-items: flex-end;
+      align-items: baseline;
       line-height: var(--line-height-small);
       overflow: hidden;
     }


### PR DESCRIPTION
Fixes an issue caused by this commit: https://github.com/discourse/discourse/pull/20643


Before (note the status alignment):
![Screenshot 2023-03-10 at 3 46 25 PM](https://user-images.githubusercontent.com/1681963/224425128-55270a68-9a24-4cef-923b-f249c2fe85d7.png)


After:
![Screenshot 2023-03-10 at 3 46 31 PM](https://user-images.githubusercontent.com/1681963/224425095-6db6ab48-9710-4d3f-9814-56791d2495fc.png)
