### PR TITLE
UX: clearer assign messages on first post

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -704,6 +704,7 @@ function initialize(api) {
       if (assignedToUser) {
         assigneeElements.push(
           h("span.assignee", [
+            h("span", `${I18n.t("discourse_assign.topic_to")} `),
             h(
               "a",
               {
@@ -720,6 +721,7 @@ function initialize(api) {
       if (assignedToGroup) {
         assigneeElements.push(
           h("span.assignee", [
+            h("span", `${I18n.t("discourse_assign.topic_to")} `),
             h(
               "a",
               {
@@ -747,7 +749,10 @@ function initialize(api) {
                     href: `${topic.url}/${postNumber}`,
                   },
                 },
-                `#${postNumber} ${assignee.username || assignee.name}`
+                I18n.t("discourse_assign.assign_post_to", {
+                  post_number: postNumber,
+                  username: assignee.username || assignee.name,
+                })
               ),
             ])
           );
@@ -756,7 +761,7 @@ function initialize(api) {
       if (!isEmpty(assigneeElements)) {
         return h("p.assigned-to", [
           assignedToUser ? iconNode("user-plus") : iconNode("group-plus"),
-          h("span.assign-text", I18n.t("discourse_assign.assigned_to")),
+          h("span.assign-text", I18n.t("discourse_assign.assigned")),
           assigneeElements,
         ]);
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -27,6 +27,8 @@ en:
       assigned: "Assigned"
       group_everyone: "Everyone"
       assigned_to: "Assigned to"
+      topic_to: "topic to"
+      assign_post_to: "#%{post_number} to %{username}"
       assigned_to_w_ellipsis: "Assigned to..."
       assign_notification: "<p><span>%{username}</span> %{description}</p>"
       assign_group_notification: "<p><span>%{username}</span> %{description}</p>"


### PR DESCRIPTION
This is a little more verbose, but fixes the grammar for assigning to post and specifies topic assigns

`Assigned to #2 discobot` -> `Assigned #2 to discobot`

`Assigned to awesomerobot, #2 discobot` -> `Assigned topic to awesomerobot, #2 to discobot`


Before:
![Screenshot 2023-03-10 at 4 43 59 PM](https://user-images.githubusercontent.com/1681963/224434113-4d390803-3413-4b7c-9fdf-a4fd59e87bad.png)

After: 
![Screenshot 2023-03-10 at 4 40 37 PM](https://user-images.githubusercontent.com/1681963/224434153-9ae44cfc-ecbb-4c23-80b4-2e52dfa680d4.png)
