### PR TITLE
FIX: Missing actions label/icon

### DIFF
--- a/assets/javascripts/discourse/components/assign-actions-dropdown.js
+++ b/assets/javascripts/discourse/components/assign-actions-dropdown.js
@@ -5,9 +5,13 @@ import { action } from "@ember/object";
 export default DropdownSelectBoxComponent.extend({
   classNames: ["assign-actions-dropdown"],
   headerIcon: null,
-  title: "...",
   allowInitialValueMutation: false,
   showFullTitle: true,
+  selectKitOptions: {
+    icon: null,
+    translatedNone: "...",
+    showFullTitle: true,
+  },
 
   computeContent() {
     let options = [];


### PR DESCRIPTION
**This PR** fixes the missing actions "..." indicator in the `assign-actions-dropdown`

Before:
<img width="1106" alt="Screenshot 2023-03-13 at 09 26 36" src="https://user-images.githubusercontent.com/30090424/224764545-207a90a2-34ec-45d1-b579-60c01e9b778b.png">

After:
<img width="1124" alt="Screenshot 2023-03-13 at 09 26 20" src="https://user-images.githubusercontent.com/30090424/224764466-9ce14ab5-2b5a-4591-aa9a-7c2394f841b4.png">

