### PR TITLE
FIX: Also evaluate list controller extensions

### DIFF
--- a/lib/discourse_assign/list_controller_extension.rb
+++ b/lib/discourse_assign/list_controller_extension.rb
@@ -3,7 +3,7 @@
 module DiscourseAssign
   module ListControllerExtension
     def self.prepended(base)
-      base.class_eval { generate_message_route(:private_messages_assigned) }
+      base.class_eval { ListController.generate_message_route(:private_messages_assigned) }
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -40,6 +40,7 @@ after_initialize do
 
   reloadable_patch do |plugin|
     Group.class_eval { prepend DiscourseAssign::GroupExtension }
+    ListController.class_eval { prepend DiscourseAssign::ListControllerExtension }
     Post.class_eval { prepend DiscourseAssign::PostExtension }
     Topic.class_eval { prepend DiscourseAssign::TopicExtension }
     WebHook.class_eval { prepend DiscourseAssign::WebHookExtension }


### PR DESCRIPTION
A small regression of https://github.com/discourse/discourse-assign/pull/446, causing `http://<route>/u/<user>/messages/assigned` to end up 404-ing.

A lil proof it's fine meow :sparkles:

<img width="935" alt="Screenshot 2023-03-23 at 9 06 03 PM" src="https://user-images.githubusercontent.com/1555215/227213326-70057b6f-0865-4d4d-b95d-44e2d3029359.png">
