### PR TITLE
DEV: Replace #pluck_first monkey patch with native #pick

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -318,7 +318,7 @@ after_initialize do
     end
 
     user_id = topic_query.guardian.user.id if name == "me"
-    user_id ||= User.where(username_lower: name.downcase).pluck_first(:id)
+    user_id ||= User.where(username_lower: name.downcase).pick(:id)
 
     if user_id
       next(
@@ -329,7 +329,7 @@ after_initialize do
       )
     end
 
-    group_id = Group.where(name: name.downcase).pluck_first(:id)
+    group_id = Group.where(name: name.downcase).pick(:id)
 
     if group_id
       next(

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -111,15 +111,15 @@ describe "integration tests" do
 
     it "assigns topic" do
       expect do DiscourseEvent.trigger(:assign_topic, topic, user1, admin) end.to change {
-        Assignment.where(topic: topic).pluck_first(:assigned_to_id)
+        Assignment.where(topic: topic).pick(:assigned_to_id)
       }.from(nil).to(user1.id)
 
       expect do DiscourseEvent.trigger(:assign_topic, topic, user2, admin) end.to_not change {
-        Assignment.where(topic: topic).pluck_first(:assigned_to_id)
+        Assignment.where(topic: topic).pick(:assigned_to_id)
       }.from(user1.id)
 
       expect do DiscourseEvent.trigger(:assign_topic, topic, user2, admin, true) end.to change {
-        Assignment.where(topic: topic).pluck_first(:assigned_to_id)
+        Assignment.where(topic: topic).pick(:assigned_to_id)
       }.from(user1.id).to(user2.id)
     end
 


### PR DESCRIPTION
### What is this change?

We have replaced the `#pluck_first` freedom patch with the native `#pick` in core [here](https://github.com/discourse/discourse/pull/19893).

This change is updates this plugin in the same fashion.