### PR TITLE
FIX: Reassigning to a group creates an incorrect mention's link

### DIFF
--- a/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse-assign/initializers/extend-for-assigns.js
@@ -974,6 +974,7 @@ export default {
 
     withPluginApi("0.12.2", (api) => {
       api.addGroupPostSmallActionCode("assigned_group");
+      api.addGroupPostSmallActionCode("reassigned_group");
       api.addGroupPostSmallActionCode("unassigned_group");
       api.addGroupPostSmallActionCode("assigned_group_to_post");
       api.addGroupPostSmallActionCode("unassigned_group_from_post");


### PR DESCRIPTION
_Reported here_: https://meta.discourse.org/t/reassigning-to-a-group-creates-a-u-link-in-the-group-mention/263659

Reassigning to a group creates an `/u/` link in the `@group` mention instead of `/g/`.

![image](https://user-images.githubusercontent.com/360640/236219080-e01f5d29-43a1-48b2-92a7-08bcbd02f4a1.png)

The reason is the `reassigned_group` group small post action code is not registered, thus creating a user link by default.


Related Discourse code:
https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/widgets/post-small-action.js#L12-L27
https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/widgets/post-small-action.js#L82-L84