### PR TITLE
DEV: Remove `redesigned_user_menu_enabled: true` in tests

### DIFF
--- a/test/javascripts/acceptance/assigns-tab-user-menu-test.js
+++ b/test/javascripts/acceptance/assigns-tab-user-menu-test.js
@@ -202,7 +202,6 @@ acceptance(
   "Discourse Assign | user menu | user cannot assign",
   function (needs) {
     needs.user({
-      redesigned_user_menu_enabled: true, // TODO(@keegan): Remove after site setting is removed in core
       can_assign: false,
     });
     needs.settings({
@@ -221,7 +220,6 @@ acceptance(
   "Discourse Assign | user menu | assign_enabled setting is disabled",
   function (needs) {
     needs.user({
-      redesigned_user_menu_enabled: true, // TODO(@keegan): Remove after site setting is removed in core
       can_assign: false,
     });
     needs.settings({
@@ -238,7 +236,6 @@ acceptance(
 
 acceptance("Discourse Assign | user menu", function (needs) {
   needs.user({
-    redesigned_user_menu_enabled: true, // TODO(@keegan): Remove after site setting is removed in core
     can_assign: true,
     grouped_unread_notifications: {
       34: 173, // assigned notification type


### PR DESCRIPTION
This PR removes the usage of `redesigned_user_menu_enabled: true` in the `assigns-tab-user-menu-test.js` as its no longer needed as of the removal of the legacy user menu in core (https://github.com/discourse/discourse/commit/082821c754ce95aefdc5c69e6d0eea4057bcd5b5)

A `.discourse-compatibility` file entry is not needed in this case as there is already a commit hash present for `3.1.0.beta3`