### PR TITLE
FEATURE: invite user/group to PM if not a participant already.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,6 +10,7 @@ en:
     unassign_on_group_archive: "When a message is archived by a group, unassign message (reassign if moved back to inbox)"
     unassign_on_close: "When a topic is closed unassign topic"
     reassign_on_open: "When a topic is opened reassign previously assigned users/groups"
+    invite_on_assign: "When a personal message is assigned to a user or group, invite them to the PM if they are not already a participant."
     assign_mailer: "When to send notification email for assignments"
     remind_assigns: "Remind users about pending assigns."
     remind_assigns_frequency: "Frequency for reminding users about assigned topics."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ plugins:
   unassign_on_close: false
   unassign_on_group_archive: false
   reassign_on_open: false
+  invite_on_assign: false
   assigns_user_url_path:
     client: true
     default: "/u/{username}/activity/assigned"

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -726,16 +726,24 @@ RSpec.describe Assigner do
     end
 
     it "invites group to the PM" do
-      group = Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:only_admins], messageable_level: Group::ALIAS_LEVELS[:only_admins])
+      group =
+        Fabricate(
+          :group,
+          assignable_level: Group::ALIAS_LEVELS[:only_admins],
+          messageable_level: Group::ALIAS_LEVELS[:only_admins],
+        )
       assigner.assign(group)
       expect(topic.allowed_groups).to include(group)
     end
 
     it "doesn't invite group to the PM if it's not messageable" do
-      group = Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:only_admins], messageable_level: Group::ALIAS_LEVELS[:nobody])
-      expect {
-        assigner.assign(group)
-      }.to raise_error(Discourse::InvalidAccess)
+      group =
+        Fabricate(
+          :group,
+          assignable_level: Group::ALIAS_LEVELS[:only_admins],
+          messageable_level: Group::ALIAS_LEVELS[:nobody],
+        )
+      expect { assigner.assign(group) }.to raise_error(Discourse::InvalidAccess)
     end
   end
 


### PR DESCRIPTION
When a group or user is assigned to a personal message, if they are not already a participant then invite them to the PM before assignment.