### PR TITLE
FIX: don't invite user when already a member of an allowed group.

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -266,7 +266,7 @@ class ::Assigner
           topic.invite_group(@assigned_by, assign_to)
         end
       else
-        unless topic.topic_allowed_users.exists?(user_id: assign_to.id)
+        unless topic.all_allowed_users.exists?(id: assign_to.id)
           guardian.ensure_can_invite_to!(topic)
           topic.invite(@assigned_by, assign_to.username)
         end

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -725,6 +725,14 @@ RSpec.describe Assigner do
       expect(topic.allowed_users).to include(user)
     end
 
+    it "doesn't invite user to the PM when already a member of an allowed group" do
+      user = Fabricate(:user)
+      assign_allowed_group.add(user)
+      topic.allowed_groups << assign_allowed_group
+      assigner.assign(user)
+      expect(topic.allowed_users).not_to include(user)
+    end
+
     it "invites group to the PM" do
       group =
         Fabricate(


### PR DESCRIPTION
Otherwise, when an allowed group member is assigned to the PM it invites the user (which is unnecessary) and creates a public small post for the invite.