### PR TITLE
UX: constrain avatar size due to core change

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -176,10 +176,14 @@
 
 #topic-footer-dropdown-reassign {
   .name {
-    font-weight: normal !important;
+    font-weight: normal;
+    display: flex;
+    align-items: center;
   }
   .avatar {
     margin-right: 0.25em;
+    width: 1.33em;
+    height: 1.33em;
   }
   .d-icon,
   i.fa {


### PR DESCRIPTION
We reduced the number of avatar sizes in https://github.com/discourse/discourse/commit/c2332d7505379c30e11d295d90f5224385736993, so the avatar in the assign footer button was too large and causing the button to be too tall. This centers it and shrinks the avatar back to the previous size (20px square)