### PR TITLE
DEV: Fix Zeitwerk reloading error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ DiscourseAssign::Engine.routes.draw do
   get "/user-menu-assigns" => "assign#user_menu_assigns"
 end
 
-Discourse::Application.routes.append do
+Discourse::Application.routes.draw do
   mount ::DiscourseAssign::Engine, at: "/assign"
 
   get "topics/private-messages-assigned/:username" => "list#private_messages_assigned",


### PR DESCRIPTION
Using `.append` can lead to a 'two routes with the same name' error when autoloading