### PR TITLE
FIX: Sum assignments for group and group users

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -125,7 +125,7 @@ module DiscourseAssign
 
       guardian.ensure_can_see_group_members!(group)
 
-      members =
+      users_with_assignments_count =
         User
           .joins("LEFT OUTER JOIN group_users g ON g.user_id = users.id")
           .joins(
@@ -140,25 +140,22 @@ module DiscourseAssign
           .limit(limit)
           .offset(offset)
 
-      members = members.where(<<~SQL, pattern: "%#{params[:filter]}%") if params[:filter]
+      users_with_assignments_count =
+        users_with_assignments_count.where(<<~SQL, pattern: "%#{params[:filter]}%") if params[
           users.name ILIKE :pattern OR users.username_lower ILIKE :pattern
         SQL
-
-      group_assignments =
-        Topic
-          .joins("JOIN assignments a ON a.topic_id = topics.id")
-          .where(<<~SQL, group_id: group.id)
-          a.assigned_to_id = :group_id AND a.assigned_to_type = 'Group' AND a.active
-        SQL
-          .pluck(:topic_id)
-
-      assignments =
-        TopicQuery.new(current_user).group_topics_assigned_results(group).pluck("topics.id")
+        :filter
+      ]
+      group_assignments_count = Assignment.active_for_group(group).count
+      users_assignments_count =
+        users_with_assignments_count.reduce(0) do |sum, assignment|
+          sum + assignment.assignments_count
+        end
 
       render json: {
-               members: serialize_data(members, GroupUserAssignedSerializer),
-               assignment_count: (assignments | group_assignments).count,
-               group_assignment_count: group_assignments.count,
+               members: serialize_data(users_with_assignments_count, GroupUserAssignedSerializer),
+               assignment_count: users_assignments_count + group_assignments_count,
+               group_assignment_count: group_assignments_count,
              }
     end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -15,6 +15,8 @@ class Assignment < ActiveRecord::Base
           )
         }
 
+  scope :active_for_group, ->(group) { where(assigned_to: group, active: true) }
+
   before_validation :default_status
 
   validate :validate_status, if: -> { SiteSetting.enable_assign_status }

--- a/spec/fabricators/assignment_fabricator.rb
+++ b/spec/fabricators/assignment_fabricator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Fabricator(:topic_assignment, class_name: :assignment) do
+  topic
+  target { |attrs| attrs[:topic] }
+  target_type "Topic"
+  assigned_by_user { Fabricate(:user) }
+  assigned_to { Fabricate(:user) }
+end
+
+Fabricator(:post_assignment, class_name: :assignment) do
+  topic { |attrs| attrs[:post]&.topic || Fabricate(:topic) }
+  target { |attrs| attrs[:post] || Fabricate(:post, topic: attrs[:topic]) }
+  target_type "Post"
+  assigned_by_user { Fabricate(:user) }
+  assigned_to { Fabricate(:user) }
+end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Assignment do
+  fab!(:group) { Fabricate(:group) }
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+  fab!(:group_user1) { Fabricate(:group_user, user: user1, group: group) }
+  fab!(:group_user1) { Fabricate(:group_user, user: user2, group: group) }
+
+  fab!(:wrong_group) { Fabricate(:group) }
+
+  before { SiteSetting.assign_enabled = true }
+
+  describe "#active_for_group" do
+    it "returns active assignments for the group" do
+      assignment1 = Fabricate(:topic_assignment, assigned_to: group)
+      assignment2 = Fabricate(:post_assignment, assigned_to: group)
+      Fabricate(:post_assignment, assigned_to: group, active: false)
+      Fabricate(:post_assignment, assigned_to: user1)
+      Fabricate(:topic_assignment, assigned_to: wrong_group)
+
+      expect(Assignment.active_for_group(group)).to contain_exactly(assignment1, assignment2)
+    end
+  end
+end


### PR DESCRIPTION
Related: https://meta.discourse.org/t/bad-group-assignment-count/252636

Use the `Assignment` count rather than the number of `Topic` assigned. 

e.g. John can be assigned to topic_id: 1, and Jane can be assigned to a post within topic_id: 1. This will result in 1 rather than 2.

Before:

The sum doesn't add up.

![image](https://github.com/discourse/discourse-assign/assets/1555215/ae293f1d-4671-466a-9fcf-b56f2c1f7b14)

There's a flicker in the number in the nav.

https://github.com/discourse/discourse-assign/assets/1555215/786d18ee-1505-41ff-b543-2cd81ce2ff09

After:

The nav number will just be a sum of all assignments, user+group.

https://github.com/discourse/discourse-assign/assets/1555215/12f28b66-238b-4445-8229-127e73825e52

There is still another bug we are seeing where it's likely that this line with the `limit` is causing issues with accuracy. But that will be looked at in another PR.

https://github.com/discourse/discourse-assign/blob/2bff29e919bc21d610c24c75299bd97090052d04/app/controllers/discourse_assign/assign_controller.rb#L128-L141