### PR TITLE
DEV: Fix flaky system tests

### DIFF
--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -60,7 +60,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
 
         expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
-        find(".topic-footer-main-buttons .toggle-admin-menu").click
+        find(".timeline-controls .toggle-admin-menu").click
         find(".topic-admin-close").click
 
         expect(find("#post_3")).to have_content(
@@ -79,7 +79,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
 
         expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
-        find(".topic-footer-main-buttons .toggle-admin-menu").click
+        find(".timeline-controls .toggle-admin-menu").click
         find(".topic-admin-close").click
 
         expect(find("#post_3")).to have_content(
@@ -108,7 +108,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
 
           expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
-          find(".topic-footer-main-buttons .toggle-admin-menu").click
+          find(".timeline-controls .toggle-admin-menu").click
           find(".topic-admin-close").click
 
           expect(find("#post_3")).to have_content(
@@ -117,7 +117,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
           expect(page).to have_no_css("#post_4")
           expect(page).to have_no_css("#topic .assigned-to")
 
-          find(".topic-footer-main-buttons .toggle-admin-menu").click
+          find(".timeline-controls .toggle-admin-menu").click
           find(".topic-admin-open").click
 
           expect(find("#post_4")).to have_content(


### PR DESCRIPTION
Why this change?

For some reason, toggling the topic admin menu via the button in the
footer is causing the test to be flaky. I don't have enough time to
figure out the root cause but we want to avoid these tests being flaky.
As such we'll use the topic admin menu in the timeline instead to close
the topic.