### PR TITLE
DEV: Fix incorrect fabrication leading to index violation errors

### DIFF
--- a/spec/requests/assign_controller_spec.rb
+++ b/spec/requests/assign_controller_spec.rb
@@ -344,17 +344,19 @@ RSpec.describe DiscourseAssign::AssignController do
 
     fab!(:assignments) do
       Fabricate(
-        :post_assignment,
+        :topic_assignment,
         assigned_to: other_allowed_user,
         target: topic,
         assigned_by_user: admin,
       )
+
       Fabricate(
-        :topic_assignment,
+        :post_assignment,
         assigned_to: other_allowed_user,
         target: post_in_same_topic,
         assigned_by_user: admin,
       )
+
       Fabricate(:topic_assignment, assigned_to: allowed_user, assigned_by_user: admin)
       Fabricate(:topic_assignment, assigned_to: other_allowed_user, assigned_by_user: admin)
 


### PR DESCRIPTION
This was causing the tests to be flaky with the following errors on CI:

```
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_assignments_on_target_id_and_target_type"
       DETAIL:  Key (target_id, target_type)=(39, Topic) already exists.
```