### PR TITLE
DEV: Try to make system tests more stable

### DIFF
--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -63,7 +63,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
         expect(assign_modal).to be_closed
         expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
-        find("#topic-footer-buttons .toggle-admin-menu").click
+        find(".timeline-controls .toggle-admin-menu").click
         find(".topic-admin-close").click
 
         expect(find("#post_3")).to have_content(
@@ -83,7 +83,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
         expect(assign_modal).to be_closed
         expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
-        find("#topic-footer-buttons .toggle-admin-menu").click
+        find(".timeline-controls .toggle-admin-menu").click
         find(".topic-admin-close").click
 
         expect(find("#post_3")).to have_content(
@@ -113,7 +113,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
           expect(assign_modal).to be_closed
           expect(topic_page).to have_assigned(user: staff_user, at_post: 2)
 
-          find("#topic-footer-buttons .toggle-admin-menu").click
+          find(".timeline-controls .toggle-admin-menu").click
           find(".topic-admin-close").click
 
           expect(find("#post_3")).to have_content(
@@ -122,7 +122,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
           expect(page).to have_no_css("#post_4")
           expect(page).to have_no_css("#topic .assigned-to")
 
-          find("#topic-footer-buttons .toggle-admin-menu").click
+          find(".timeline-controls .toggle-admin-menu").click
           find(".topic-admin-open").click
 
           expect(find("#post_4")).to have_content(


### PR DESCRIPTION
Why this change?

We have been seeing tests failures due to errors like

```
Capybara::ElementNotFound:
  Unable to find css "#topic-footer-button-assign"
```

when running our system tests in CI. However, I can't quite figure out
why that is happening and have invested way too much time to do so.
Therefore, I'm trying to fix this by closing a topic via the topic
timeline controls instead of the footer button instead.

Example of test failure: https://github.com/discourse/discourse/actions/runs/5525940028/jobs/10080088908