### PR TITLE
DEV: skip flakey spec

### DIFF
--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -73,7 +73,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
         expect(page).to have_no_css("#topic .assigned-to")
       end
 
-      it "can assign the previous assignee" do
+      xit "can assign the previous assignee" do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic


### PR DESCRIPTION
We already tried to make this spec more reliable in https://github.com/discourse/discourse-assign/commit/eb3b97b834a84a588da36a45a29279e6dd83d406 but that didn't work out.

https://github.com/discourse/discourse/actions/runs/5694495045/job/15435791690?pr=22860