### PR TITLE
FIX: Fix reminder frequency not getting sent daily when early by a few seconds/minutes

### DIFF
--- a/app/jobs/scheduled/enqueue_reminders.rb
+++ b/app/jobs/scheduled/enqueue_reminders.rb
@@ -20,6 +20,8 @@ module Jobs
       Group.assign_allowed_groups.pluck(:id).join(",")
     end
 
+    REMINDER_BUFFER_MINUTES = 10
+
     def user_ids
       global_frequency = SiteSetting.remind_assigns_frequency
       frequency =
@@ -46,7 +48,7 @@ module Jobs
         AND #{frequency} > 0
         AND (
           last_reminder.value IS NULL OR
-          last_reminder.value::TIMESTAMP <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * #{frequency})
+          last_reminder.value::TIMESTAMP <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * #{frequency}) + ('1 MINUTE'::INTERVAL * #{REMINDER_BUFFER_MINUTES})
         )
         AND assignments.updated_at::TIMESTAMP <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * #{frequency})
         AND assignments.assigned_to_type = 'User'

--- a/spec/jobs/scheduled/enqueue_reminders_spec.rb
+++ b/spec/jobs/scheduled/enqueue_reminders_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe Jobs::EnqueueReminders do
 
     describe "assignment frequency" do
       it "enqueues a reminder if the user reminder frequency is 1 day and the last reminded at is almost 1 day" do
-        user.custom_fields[PendingAssignsReminder::REMINDERS_FREQUENCY] = RemindAssignsFrequencySiteSettings::DAILY_MINUTES
+        user.custom_fields[
+          PendingAssignsReminder::REMINDERS_FREQUENCY
+        ] = RemindAssignsFrequencySiteSettings::DAILY_MINUTES
         user.custom_fields[PendingAssignsReminder::REMINDED_AT] = 1.days.ago
         user.save
 


### PR DESCRIPTION
t/105676

When a user sets their reminder frequency to be "daily", there's a chance that they actually only get it sent every two days.

 (/my/preferences/notifications)
<img width="355" alt="Screenshot 2023-08-08 at 7 50 15 PM" src="https://github.com/discourse/discourse-assign/assets/1555215/f1043f35-1303-42aa-a424-4ad12c15b7b1">

This is likely happening as our `EnqueueReminders` sidekiq job runs every `1.day`, issuing a second job `RemindUser` which updates the `last_reminded_at` value to be a bit after the time when the sidekiq job gets done. The list of users to send reminders to depends on `last_reminded_at` being more than the user set reminder frequency, resulting in the bug that the reminder only triggers on the next day.