### PR TITLE
DEV: Increase the buffer used to determine whether to send out the reminder email

### DIFF
--- a/app/jobs/scheduled/enqueue_reminders.rb
+++ b/app/jobs/scheduled/enqueue_reminders.rb
@@ -20,7 +20,7 @@ module Jobs
       Group.assign_allowed_groups.pluck(:id).join(",")
     end
 
-    REMINDER_BUFFER_MINUTES = 10
+    REMINDER_BUFFER_MINUTES = 60
 
     def user_ids
       global_frequency = SiteSetting.remind_assigns_frequency

--- a/app/jobs/scheduled/enqueue_reminders.rb
+++ b/app/jobs/scheduled/enqueue_reminders.rb
@@ -20,7 +20,7 @@ module Jobs
       Group.assign_allowed_groups.pluck(:id).join(",")
     end
 
-    REMINDER_BUFFER_MINUTES = 60
+    REMINDER_BUFFER_MINUTES = 120
 
     def user_ids
       global_frequency = SiteSetting.remind_assigns_frequency

--- a/spec/jobs/scheduled/enqueue_reminders_spec.rb
+++ b/spec/jobs/scheduled/enqueue_reminders_spec.rb
@@ -52,16 +52,16 @@ RSpec.describe Jobs::EnqueueReminders do
         user.custom_fields[
           PendingAssignsReminder::REMINDERS_FREQUENCY
         ] = RemindAssignsFrequencySiteSettings::DAILY_MINUTES
-        user.custom_fields[PendingAssignsReminder::REMINDED_AT] = 1.days.ago
+        user.custom_fields[PendingAssignsReminder::REMINDED_AT] = 1.days.ago + 59.minutes
         user.save
 
-        assign_multiple_tasks_to(user, assigned_on: 1.day.ago - 1.minute)
+        assign_multiple_tasks_to(user, assigned_on: 2.day.ago)
 
         assert_reminders_enqueued(1)
       end
 
       it "does not enqueue a reminder if it's too soon" do
-        user.upsert_custom_fields(PendingAssignsReminder::REMINDED_AT => 1.days.ago)
+        user.upsert_custom_fields(PendingAssignsReminder::REMINDED_AT => 1.days.ago + 60.minutes)
         assign_multiple_tasks_to(user)
 
         assert_reminders_enqueued(0)


### PR DESCRIPTION
Continuing from https://github.com/discourse/discourse-assign/pull/496

The buffer value introduced here was not enough. We are seeing that the deviation across emails across the two days (when it should be one day) is two hours. 

<img width="186" alt="Screenshot 2023-08-15 at 1 39 52 PM" src="https://github.com/discourse/discourse-assign/assets/1555215/af381f57-c0e4-4e28-9008-7fb356b7431b">

Day 1 email at 5:47PM. Assuming the next sidekiq job triggers at 5:46PM (at an earlier time the next day), the reminder will not be sent

<img width="178" alt="Screenshot 2023-08-15 at 1 39 48 PM" src="https://github.com/discourse/discourse-assign/assets/1555215/c110d650-65d5-48f6-a832-7e4faf3020a9">

Day 3 email at 4:19PM, about 2 hours earlier in the day. 

So we will use 2 hours as a buffer.