### PR TITLE
DEV: Resolve routing method deprecation

### DIFF
--- a/assets/javascripts/discourse/routes/group-assigned.js
+++ b/assets/javascripts/discourse/routes/group-assigned.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { ajax } from "discourse/lib/ajax";
+import { inject as service } from "@ember/service";
 
 export default class GroupAssigned extends DiscourseRoute {
+  @service router;
+
   model() {
     return ajax(`/assign/members/${this.modelFor("group").name}`);
   }
@@ -21,10 +24,8 @@ export default class GroupAssigned extends DiscourseRoute {
   }
 
   redirect(model, transition) {
-    if (transition.to.params.hasOwnProperty("filter")) {
-      this.transitionTo("group.assigned.show", transition.to.params.filter);
-    } else {
-      this.transitionTo("group.assigned.show", "everyone");
+    if (!transition.to.params.hasOwnProperty("filter")) {
+      this.router.transitionTo("group.assigned.show", "everyone");
     }
   }
 }


### PR DESCRIPTION
Uses the router service for redirecting instead of `this.transitionTo`. Also removes the first branch of logic, which was unnecessarily redirecting to the current route (and led to an infinite loop with the modern API)