### PR TITLE
UX: Don't change topic notification level when unassigning

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -372,22 +372,6 @@ class ::Assigner
         assigned_to_type: assignment.assigned_to_type,
       )
 
-      if assignment.assigned_to_user?
-        if TopicUser.exists?(
-             user_id: assignment.assigned_to_id,
-             topic: topic,
-             notification_level: TopicUser.notification_levels[:watching],
-             notifications_reason_id: TopicUser.notification_reasons[:plugin_changed],
-           )
-          TopicUser.change(
-            assignment.assigned_to_id,
-            topic.id,
-            notification_level: TopicUser.notification_levels[:tracking],
-            notifications_reason_id: TopicUser.notification_reasons[:plugin_changed],
-          )
-        end
-      end
-
       assigned_to = assignment.assigned_to
 
       if SiteSetting.unassign_creates_tracking_post && !silent

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Assigner do
       expect(TopicQuery.new(moderator, assigned: moderator.username).list_latest.topics).to eq([])
 
       expect(TopicUser.find_by(user: moderator).notification_level).to eq(
-        TopicUser.notification_levels[:tracking],
+        TopicUser.notification_levels[:watching],
       )
     end
 

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -122,23 +122,17 @@ RSpec.describe Assigner do
       }
     end
 
-    it "does not update notification level if it is not set by the plugin" do
+    it "does not update notification level when unassigned" do
       assigner.assign(moderator)
 
       expect(TopicUser.find_by(user: moderator).notification_level).to eq(
         TopicUser.notification_levels[:watching],
       )
 
-      TopicUser.change(
-        moderator.id,
-        topic.id,
-        notification_level: TopicUser.notification_levels[:muted],
-      )
-
       assigner.unassign
 
       expect(TopicUser.find_by(user: moderator, topic: topic).notification_level).to eq(
-        TopicUser.notification_levels[:muted],
+        TopicUser.notification_levels[:watching],
       )
     end
 


### PR DESCRIPTION
Currently, when unassigning a topic, we change the topic's notification level to `TopicUser.notification_levels[:tracking]` if it was originally set by a plugin and the user was not watching it originally.

We've found that assignees tend to want to still watch the topic for any input despite being unassigned.

This PR removes that notification level change, and keeps notification level as-is.