### PR TITLE
UX: simplify markup to fix j/k highlighting

### DIFF
--- a/assets/javascripts/discourse/components/assigned-topic-list-column.gjs
+++ b/assets/javascripts/discourse/components/assigned-topic-list-column.gjs
@@ -5,7 +5,6 @@ import { action } from "@ember/object";
 
 export default class AssignedTopicListColumn extends Component {
   <template>
-    <td class="topic-list-data">
       {{#if @topic.assigned_to_user}}
         <AssignActionsDropdown
           @topic={{@topic}}
@@ -24,7 +23,6 @@ export default class AssignedTopicListColumn extends Component {
       {{else}}
         <AssignActionsDropdown @topic={{@topic}} @unassign={{this.unassign}} />
       {{/if}}
-    </td>
   </template>
 
   @service taskActions;

--- a/assets/javascripts/discourse/raw-views/assign-topic-buttons.gjs
+++ b/assets/javascripts/discourse/raw-views/assign-topic-buttons.gjs
@@ -12,7 +12,7 @@ export default class extends EmberObject {
     if (ASSIGN_LIST_ROUTES.includes(this.router.currentRouteName)) {
       return rawRenderGlimmer(
         this,
-        "div.assign-topic-buttons",
+        "td.assign-topic-buttons",
         <template><AssignedTopicListColumn @topic={{@data.topic}} /></template>,
         { topic: this.topic }
       );


### PR DESCRIPTION
This cleans up the markup a bit, so instead of a `div` as a table child we use the `td` and removes the internal wrapper. This fixes an issue with a double highlight while using j/k navigation highlighting caused by the nested `td`. 



Before:
```html
<div>
  <td>
   dropdown here
  </td
</div>  
```

![Screenshot 2023-10-19 at 6 21 13 PM](https://github.com/discourse/discourse-assign/assets/1681963/b5aa8ac5-208a-4f27-ae2d-4b724528a582)

After:
```html
<td>
 dropdown here
</td
```

![Screenshot 2023-10-19 at 6 18 05 PM](https://github.com/discourse/discourse-assign/assets/1681963/62c7aa4d-0503-4df3-891f-c0728b9f96a5)
