### PR TITLE
DEV: Fix a flaky spec

### DIFF
--- a/spec/lib/random_assign_utils_spec.rb
+++ b/spec/lib/random_assign_utils_spec.rb
@@ -207,10 +207,12 @@ RSpec.describe RandomAssignUtils do
     end
 
     context "when assigned_topic is not found" do
-      let(:fields) { { "assigned_topic" => { "value" => 1 } } }
+      let(:fields) do
+        { "assigned_topic" => { "value" => -1 }, "assignees_group" => { "value" => group_1.id } }
+      end
 
       it "raises an error" do
-        expect { auto_assign }.to raise_error(/Topic\(1\) not found/)
+        expect { auto_assign }.to raise_error(/Topic\(-1\) not found/)
       end
     end
 


### PR DESCRIPTION
Sometimes, the topic id actually exists for that spec (id being 1) and it will raise about not finding the group id instead of not finding the provided topic because the assignees group wasn’t provided in the `fields` parameter.