### PR TITLE
DEV: Fix flaky system tests

### DIFF
--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -34,7 +34,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
     context "when assigns are not public" do
       before { SiteSetting.assigns_public = false }
 
-      it "assigned small action post has 'private-assign' in class attribute" do
+      it "assigned small action post has 'private-assign' in class attribute", capture_log: true do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic


### PR DESCRIPTION
Why this change?

The spec is flaky and it seems to be DB transaction related where after signing in as a user, the failure screenshot shows that the user has not been signed in.

What does this change do?

Set `capture_log: true` which will log all ActiveRecord DB statements execute while running the spec.