### PR TITLE
DEV: Capture logs for all tests in `spec/system/assign_topic_spec.rb`

### DIFF
--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Assign | Assigning topics", type: :system, js: true do
+describe "Assign | Assigning topics", type: :system, capture_log: true do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:assign_modal) { PageObjects::Modals::Assign.new }
   fab!(:staff_user) { Fabricate(:user, groups: [Group[:staff]]) }
@@ -10,6 +10,10 @@ describe "Assign | Assigning topics", type: :system, js: true do
 
   before do
     SiteSetting.assign_enabled = true
+
+    # The system tests in this file are flaky and auth token related so turning this on
+    SiteSetting.verbose_auth_token_logging = true
+
     sign_in(admin)
   end
 
@@ -34,7 +38,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
     context "when assigns are not public" do
       before { SiteSetting.assigns_public = false }
 
-      it "assigned small action post has 'private-assign' in class attribute", capture_log: true do
+      it "assigned small action post has 'private-assign' in class attribute" do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic
@@ -73,7 +77,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
         expect(page).to have_no_css("#topic .assigned-to")
       end
 
-      it "can assign the previous assignee", capture_log: true do
+      it "can assign the previous assignee" do
         visit "/t/#{topic.id}"
 
         topic_page.click_assign_topic
@@ -103,7 +107,7 @@ describe "Assign | Assigning topics", type: :system, js: true do
       context "when reassign_on_open is set to true" do
         before { SiteSetting.reassign_on_open = true }
 
-        it "reassigns the topic on open", capture_log: true do
+        it "reassigns the topic on open" do
           visit "/t/#{topic.id}"
 
           topic_page.click_assign_topic


### PR DESCRIPTION
Why this change?

We have been getting flaky test failures from these specs and the failure screenshot shows that the user is not logged in when it is supposed to be. Futher investigation shows that when the test flakes, it is because the request to view the topic is using an auth token that is different from the one which was created when the user was signed in.

What does this change do?

1. Add the `capture_log` metadata to all the tests in this file.

2. Enables the `verbose_auth_token_logging` site setting to give us more debugging information in the logs.