### PR TITLE
DEV:  Remove `capture_logs: true` metadata

### DIFF
--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Assign | Assigning topics", type: :system, capture_log: true do
+describe "Assign | Assigning topics", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:assign_modal) { PageObjects::Modals::Assign.new }
   fab!(:staff_user) { Fabricate(:user, groups: [Group[:staff]]) }


### PR DESCRIPTION
Why this change?

We believe we have figured out the problem and not longer need the debugging information.