### PR TITLE
UX: autofocus assignee input

### DIFF
--- a/assets/javascripts/discourse/components/assign-user-form.hbs
+++ b/assets/javascripts/discourse/components/assign-user-form.hbs
@@ -13,7 +13,6 @@
       )
       groupMembersOf=this.taskActions.allowedGroups
       maximum=1
-      autofocus=(not this.capabilities.touch)
       tabindex=1
       expandedOnInsert=(not this.assigneeName)
       caretUpIcon="search"


### PR DESCRIPTION
With the new mobile modal we can now do this with no issue. Prior to this change we would have to click two times on search input to show keyboard, now only one.