### PR TITLE
FIX: Assignments limit shouldn't prevent from reassigning a post

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -547,8 +547,7 @@ class ::Assigner
   end
 
   def reassign?
-    return false if !@target.is_a?(Topic)
-    Assignment.exists?(topic_id: @target.id, target: @target, active: true)
+    Assignment.exists?(target: @target, active: true)
   end
 
   def no_assignee_change?(assignee)

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Assigner do
         expect(second_assign[:success]).to eq(true)
       end
 
-      it "assignments limit doesn't prevent from reassigning a post" do
+      it "reassigns a post even when at the assignments limit" do
         posts =
           (described_class::ASSIGNMENTS_PER_TOPIC_LIMIT).times.map do
             Fabricate(:post, topic: topic)

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -264,6 +264,21 @@ RSpec.describe Assigner do
         expect(second_assign[:success]).to eq(true)
       end
 
+      it "assignments limit doesn't prevent from reassigning a post" do
+        posts =
+          (described_class::ASSIGNMENTS_PER_TOPIC_LIMIT).times.map do
+            Fabricate(:post, topic: topic)
+          end
+
+        posts.each do |post|
+          user = Fabricate(:moderator)
+          described_class.new(post, admin).assign(user)
+        end
+
+        status = described_class.new(posts.first, admin).assign(Fabricate(:moderator))
+        expect(status[:success]).to eq(true)
+      end
+
       context "when 'allow_self_reassign' is false" do
         subject(:assign) do
           assigner.assign(moderator, note: other_note, allow_self_reassign: self_reassign)


### PR DESCRIPTION
At the moment, it's possible to have maximum [5 assignments](https://github.com/discourse/discourse-assign/blob/08c2a4e0f392718fd821ce10a52186f04323e439/lib/assigner.rb#L7) per topic (that includes topic and post assignments). When trying to assign more, this message appears:

<img width="450" alt="Screenshot 2024-03-26 at 21 09 49" src="https://github.com/discourse/discourse-assign/assets/1274517/0070c651-995e-4ca6-a12a-c49c0fdea788">

One possible edge case here is reassigning a topic or a post. Reassignment doesn't lead to exceeding the limit, and therefore it should be possible. But at the moment we handle correctly only _topic_  reassignments, while when reassigning a _post_, we show the error message "the limit has been reached".

This PR makes post reassignments work correctly too.

