### PR TITLE
FIX: Unassign buttons on the activity/assigned page don't work

### DIFF
--- a/assets/javascripts/discourse/components/assign-actions-dropdown.js
+++ b/assets/javascripts/discourse/components/assign-actions-dropdown.js
@@ -52,7 +52,7 @@ export default DropdownSelectBoxComponent.extend({
   },
 
   @action
-  onSelect(id) {
+  onChange(id) {
     switch (id) {
       case "unassign":
         this.unassign(this.topic.id);


### PR DESCRIPTION
We've noticed problems when unassigning a topic on the `activity/assigned` page using this button:

<img width="600" alt="Screenshot 2024-04-04 at 18 59 03" src="https://github.com/discourse/discourse-assign/assets/1274517/3c7b3508-3d41-48cf-bf88-058203647761">

One of two incorrect things happens when pressing this button:
1. The first topic on the page gets unassigned instead of the selected one
2. No topics get unassigned (that happens when the first topic on the list is not assigned and only has assigned _posts_)

That happens because this handler for all buttons somehow always use the same state - the state of the first topic on the page:

https://github.com/discourse/discourse-assign/blob/f2906e088561a970e14049273a5be9669eef2672/assets/javascripts/discourse/components/assign-actions-dropdown.js#L55-L68

There seem to be some nuances in select-kit and I'm not sure whether this should be qualified as a bug in select-kit. However, I've noticed that in other cases when we use `DropdownSelectBoxComponent` we use the `onChange` handler rather than `onSelect`.

So I switched this code to using `onChange` and that resolved the issue, the `onChange` handler has access to correct state.

Tests will be in a follow-up.