### PR TITLE
FIX: correctly refresh UI when changing group preference

### DIFF
--- a/assets/javascripts/discourse/connectors/groups-interaction-custom-options/assignable-interaction-fields.hbs
+++ b/assets/javascripts/discourse/connectors/groups-interaction-custom-options/assignable-interaction-fields.hbs
@@ -14,7 +14,7 @@
     @valueProperty="value"
     @value={{this.assignableLevel}}
     @content={{this.assignableLevelOptions}}
-    @onChange={{action (mut @outletArgs.model.assignable_level)}}
+    @onChange={{this.onChangeAssignableLevel}}
     class="groups-form-assignable-level"
   />
 </div>

--- a/assets/javascripts/discourse/connectors/groups-interaction-custom-options/assignable-interaction-fields.js
+++ b/assets/javascripts/discourse/connectors/groups-interaction-custom-options/assignable-interaction-fields.js
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
 import I18n from "I18n";
 
 export default class AssignableInteractionFields extends Component {
@@ -12,6 +13,11 @@ export default class AssignableInteractionFields extends Component {
   ];
 
   get assignableLevel() {
-    return this.args.outletArgs.model.assignable_level || 0;
+    return this.args.outletArgs.model.get("assignable_level") || 0;
+  }
+
+  @action
+  onChangeAssignableLevel(level) {
+    this.args.outletArgs.model.set("assignable_level", level);
   }
 }

--- a/spec/system/group_preferences_spec.rb
+++ b/spec/system/group_preferences_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "Assign | Group Preferences", type: :system, js: true do
+  fab!(:admin)
+  fab!(:group)
+
+  before do
+    SiteSetting.assign_enabled = true
+    sign_in(admin)
+  end
+
+  it "allows to change who can assign a group" do
+    visit "/g/#{group.name}/manage/interaction"
+    select_kit = PageObjects::Components::SelectKit.new(".groups-form-assignable-level")
+
+    expect(select_kit).to have_selected_value(0)
+
+    select_kit.expand
+    select_kit.select_row_by_value(99)
+
+    expect(select_kit).to have_selected_value(99)
+
+    page.find(".group-manage-save").click
+    visit "/g/#{group.name}/manage/interaction"
+
+    expect(select_kit).to have_selected_value(99)
+  end
+end


### PR DESCRIPTION
Prior to this fix the state change was not reflected in the UI when changing the "who can assign" preference of a group.

This was actually saved in the backend but would require a full page refresh to see the updated state on the group preferences page.