### PR TITLE
FIX: Unassign label sometimes touches avatar

### DIFF
--- a/assets/javascripts/discourse/components/topic-level-assign-menu.js
+++ b/assets/javascripts/discourse/components/topic-level-assign-menu.js
@@ -62,13 +62,7 @@ export default {
   },
 
   noneItem() {
-    const topic = this.topic;
-
-    if (topic.assigned_to_user || topic.hasAssignedPosts()) {
-      return unassignUsersButton(topic.uniqueAssignees());
-    } else if (topic.assigned_to_group) {
-      return unassignGroupButton(topic.assigned_to_group);
-    }
+    return topicLevelUnassignButton(this.topic.uniqueAssignees());
   },
   content() {
     const content = [];
@@ -98,39 +92,6 @@ export default {
     );
   },
 };
-
-function unassignGroupButton(group) {
-  const label = I18n.t("discourse_assign.unassign.title");
-  return {
-    id: null,
-    name: I18n.t("discourse_assign.reassign_modal.title"),
-    label: htmlSafe(
-      `<span class="unassign-label">${label}</span> @${group.name}...`
-    ),
-  };
-}
-
-function unassignUsersButton(users) {
-  let avatars = "";
-  if (users.length === 1) {
-    avatars = avatarHtml(users[0], "tiny");
-  } else if (users.length > 1) {
-    avatars =
-      avatarHtml(users[0], "tiny", "overlap") + avatarHtml(users[1], "tiny");
-  }
-
-  const label = `<span class="unassign-label">${I18n.t(
-    "discourse_assign.topic_level_menu.unassign_with_ellipsis"
-  )}</span>`;
-
-  return {
-    id: null,
-    name: htmlSafe(
-      I18n.t("discourse_assign.topic_level_menu.unassign_with_ellipsis")
-    ),
-    label: htmlSafe(`${avatars}${label}`),
-  };
-}
 
 function avatarHtml(user, size, classes) {
   return renderAvatar(user, {
@@ -224,4 +185,32 @@ function unassignFromPostButton(postId, assignment) {
     name: htmlSafe(dataName),
     label: htmlSafe(`${icon} ${label}`),
   };
+}
+
+function topicLevelUnassignButton(assignees) {
+  const avatars = topicLevelUnassignButtonAvatars(assignees);
+  const label = `<span class="unassign-label">${I18n.t(
+    "discourse_assign.topic_level_menu.unassign_with_ellipsis"
+  )}</span>`;
+
+  return {
+    id: null,
+    name: htmlSafe(
+      I18n.t("discourse_assign.topic_level_menu.unassign_with_ellipsis")
+    ),
+    label: htmlSafe(`${avatars}${label}`),
+  };
+}
+
+function topicLevelUnassignButtonAvatars(assignees) {
+  const users = assignees.filter((a) => a.username);
+  let avatars = "";
+  if (users.length === 1) {
+    avatars = avatarHtml(users[0], "tiny");
+  } else if (users.length > 1) {
+    avatars =
+      avatarHtml(users[0], "tiny", "overlap") + avatarHtml(users[1], "tiny");
+  }
+
+  return avatars;
 }


### PR DESCRIPTION
We've noticed that sometimes it looks like this:

![f39e0c927da766956e46387ef5d10b73052ace3e_2_1380x338](https://github.com/discourse/discourse-assign/assets/1274517/cdddbf52-ca2a-4f22-8f02-dbacda897bc5)

Turned out that happens when a topic has several assignments and those contain assignments to users _and_ to groups. We don't show avatars for groups, but the code saw there are several assignees and applied overlapping styling.

I corrected the logic, and that fixed the issue.

Here is how avatars on this button behave. If there are from one to many assignments on the topic, but all the assignees are groups, we don't show avatars, only label:

<img width="108" alt="Screenshot 2024-04-09 at 22 07 29" src="https://github.com/discourse/discourse-assign/assets/1274517/151c12f7-5a40-431b-ab93-c0a076fa253e">

If there are from one to many assignments to the same user we show the avatar of that user (and even if there are also assignments to groups there is no overlapping):

<img width="134" alt="Screenshot 2024-04-09 at 22 06 44" src="https://github.com/discourse/discourse-assign/assets/1274517/352bc8c1-f1f5-45a6-8a17-5abdada800f4">

And if there are from two to many assignments to different users, we show avatars of first two users:

<img width="150" alt="Screenshot 2024-04-09 at 22 07 11" src="https://github.com/discourse/discourse-assign/assets/1274517/95c92bd3-009e-4d8f-8c3c-68db6cbb1da8">



