### PR TITLE
FIX: Respect pending_assign_reminder_threshold in enqueue_reminders

### DIFF
--- a/app/jobs/scheduled/enqueue_reminders.rb
+++ b/app/jobs/scheduled/enqueue_reminders.rb
@@ -22,6 +22,10 @@ module Jobs
       Group.assign_allowed_groups.pluck(:id).join(",")
     end
 
+    def reminder_threshold
+      @reminder_threshold ||= SiteSetting.pending_assign_reminder_threshold
+    end
+
     def user_ids
       global_frequency = SiteSetting.remind_assigns_frequency
       frequency =
@@ -54,7 +58,7 @@ module Jobs
         AND assignments.assigned_to_type = 'User'
 
         GROUP BY assignments.assigned_to_id
-        HAVING COUNT(assignments.assigned_to_id) > 1
+        HAVING COUNT(assignments.assigned_to_id) >= #{reminder_threshold}
       SQL
     end
   end

--- a/spec/jobs/scheduled/enqueue_reminders_spec.rb
+++ b/spec/jobs/scheduled/enqueue_reminders_spec.rb
@@ -31,10 +31,18 @@ RSpec.describe Jobs::EnqueueReminders do
       assert_reminders_enqueued(1)
     end
 
-    it "does not enqueue a reminder when the user only has one task" do
+    it "does not enqueue a reminder when the user has fewer assignments than `pending_assign_reminder_threshold`" do
       assign_one_task_to(user)
 
       assert_reminders_enqueued(0)
+    end
+
+    it "enqueues a reminder when the user has one assignement if `pending_assign_reminder_threshold` is set to one" do
+      assign_one_task_to(user)
+
+      SiteSetting.pending_assign_reminder_threshold = 1
+
+      assert_reminders_enqueued(1)
     end
 
     it "doesn't count assigns from deleted topics" do


### PR DESCRIPTION
This is a follow-up from this commit - https://github.com/discourse/discourse-assign/commit/e3c24ba2f2c24fe073d7e65e5f247849311894f6

The commit added a threshold setting for admin to configure how many assignments a user needs to get the assignment notification. This query here did not allow for the new setting to be `1`. 