### PR TITLE
UX: smaller avatar size in button to prevent height change

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -177,8 +177,8 @@
     gap: 0.25em;
   }
   .avatar {
-    width: 1.33em;
-    height: 1.33em;
+    width: 1.19em;
+    height: 1.19em;
   }
   .avatar.overlap {
     z-index: 1;


### PR DESCRIPTION
The core font-size bump up to 16px made this avatar a little taller, which made the button slightly taller than the others (which also caused the others to increase their height, due to `align-items: stretch;` on the parent container). 

Before:
![image](https://github.com/discourse/discourse-assign/assets/1681963/20552cc5-31a1-4a24-aee3-6ec5c44003ce)


After:
![image](https://github.com/discourse/discourse-assign/assets/1681963/f262c5a9-b84b-48c4-a7da-a22bf7498998)
