### PR TITLE
FIX: ensures topics can be bulk managed on group page

### DIFF
--- a/assets/javascripts/discourse/controllers/group-assigned-show.js
+++ b/assets/javascripts/discourse/controllers/group-assigned-show.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { alias } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 import UserTopicsList from "discourse/controllers/user-topics-list";
+import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 import discourseDebounce from "discourse-common/lib/debounce";
 
@@ -16,6 +17,7 @@ export default class GroupAssignedShow extends UserTopicsList {
   ascending = false;
   search = "";
   bulkSelectEnabled = false;
+  bulkSelectHelper = new BulkSelectHelper(this);
   selected = [];
 
   @alias("currentUser.staff") canBulkSelect;

--- a/assets/javascripts/discourse/templates/group-assigned-show.hbs
+++ b/assets/javascripts/discourse/templates/group-assigned-show.hbs
@@ -30,6 +30,7 @@
     @changeSort={{action "changeSort"}}
     @toggleBulkSelect={{action "toggleBulkSelect"}}
     @bulkSelectAction={{action "refresh"}}
+    @bulkSelectHelper={{this.bulkSelectHelper}}
     @unassign={{action "unassign"}}
     @reassign={{action "reassign"}}
     @onScroll={{this.saveScrollPosition}}

--- a/spec/system/group_assigned_spec.rb
+++ b/spec/system/group_assigned_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "Assign | Group assigned", type: :system, js: true do
+  fab!(:admin)
+  fab!(:group)
+  fab!(:topic)
+  fab!(:post) { Fabricate(:post, topic: topic) }
+
+  let(:topic_list) { PageObjects::Components::TopicList.new }
+  let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+
+  before do
+    group.add(admin)
+    SiteSetting.assign_enabled = true
+    SiteSetting.assign_allowed_on_groups = group.id.to_s
+    Assigner.new(topic, Discourse.system_user).assign(admin)
+    sign_in(admin)
+  end
+
+  it "allows to bulk select assigned topics" do
+    visit "/g/#{group.name}/assigned/everyone"
+
+    topic_list_header.click_bulk_select_button
+    topic_list.click_topic_checkbox(topic)
+    find(".bulk-select-actions").click
+
+    expect(topic_list_header).to have_bulk_select_modal
+  end
+end


### PR DESCRIPTION
Since a previous refactor the bulkSelectHelper was not correctly passed in the custom topic list page of this plugin.

A spec has also been added.