### PR TITLE
FIX: prevents column reference "id" is ambiguous

### DIFF
--- a/lib/discourse_assign/group_extension.rb
+++ b/lib/discourse_assign/group_extension.rb
@@ -10,13 +10,13 @@ module DiscourseAssign
       scope :assignable,
             ->(user) do
               where(
-                "assignable_level in (:levels) OR
+                "groups.assignable_level in (:levels) OR
                   (
-                    assignable_level = #{Group::ALIAS_LEVELS[:members_mods_and_admins]} AND id in (
-                    SELECT group_id FROM group_users WHERE user_id = :user_id)
+                    groups.assignable_level = #{Group::ALIAS_LEVELS[:members_mods_and_admins]} AND groups.id in (
+                    SELECT group_id FROM group_users AS gu WHERE gu.user_id = :user_id)
                   ) OR (
-                    assignable_level = #{Group::ALIAS_LEVELS[:owners_mods_and_admins]} AND id in (
-                    SELECT group_id FROM group_users WHERE user_id = :user_id AND owner IS TRUE)
+                    groups.assignable_level = #{Group::ALIAS_LEVELS[:owners_mods_and_admins]} AND groups.id in (
+                    SELECT group_id FROM group_users as gu WHERE gu.user_id = :user_id AND gu.owner IS TRUE)
                   )",
                 levels: alias_levels(user),
                 user_id: user&.id,


### PR DESCRIPTION
I noticed this error in production log but couldn't reproduce it locally. I suspect it's related to a specific combination of plugins.

Ensuring all column names are not ambiguous in this query shouldn't hurt and should fix the problem.

context: https://meta.discourse.org/t/unable-to-search-for-users-when-assigning/322934