### PR TITLE
FIX: If a group is deleted also remove assignments

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -873,9 +873,11 @@ after_initialize do
   end
 
   on(:group_destroyed) do |group, user_ids|
-    User.where(id: user_ids).find_each do |user|
-      user.notifications.for_assignment(group.assignments.select(:id)).destroy_all if user
-    end
+    User
+      .where(id: user_ids)
+      .find_each do |user|
+        user.notifications.for_assignment(group.assignments.select(:id)).destroy_all
+      end
 
     Assignment.active_for_group(group).destroy_all
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -873,8 +873,7 @@ after_initialize do
   end
 
   on(:group_destroyed) do |group, user_ids|
-    user_ids.each do |user_id|
-      user = User.find(user_id)
+    User.where(id: user_ids).find_each do |user|
       user.notifications.for_assignment(group.assignments.select(:id)).destroy_all if user
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -872,6 +872,15 @@ after_initialize do
     end
   end
 
+  on(:group_destroyed) do |group, user_ids|
+    user_ids.each do |user_id|
+      user = User.find(user_id)
+      user.notifications.for_assignment(group.assignments.select(:id)).destroy_all if user
+    end
+
+    Assignment.active_for_group(group).destroy_all
+  end
+
   register_search_advanced_filter(/in:assigned/) do |posts|
     posts.where(<<~SQL) if @guardian.can_assign?
         topics.id IN (

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -146,5 +146,33 @@ RSpec.describe DiscourseAssign do
         expect_job_enqueued(job: Jobs::AssignNotification, args: { assignment_id: assignment.id })
       end
     end
+
+    describe "on 'group_destroyed'" do
+      let(:group) { Fabricate(:group) }
+      let(:user) { Fabricate(:user) }
+      let(:first_assignment) { Fabricate(:topic_assignment, assigned_to: group) }
+      let(:second_assignment) { Fabricate(:post_assignment, assigned_to: group) }
+
+      before do
+        group.users << user
+        Fabricate(
+          :notification,
+          notification_type: Notification.types[:assigned],
+          user: user,
+          data: { assignment_id: first_assignment.id }.to_json,
+        )
+        Fabricate(
+          :notification,
+          notification_type: Notification.types[:assigned],
+          user: user,
+          data: { assignment_id: second_assignment.id }.to_json,
+        )
+      end
+
+      it "removes user's notifications related to group assignments" do
+
+        expect { group.destroy }.to change { user.notifications.assigned.count }.by(-2)
+      end
+    end
   end
 end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -170,7 +170,6 @@ RSpec.describe DiscourseAssign do
       end
 
       it "removes user's notifications related to group assignments" do
-
         expect { group.destroy }.to change { user.notifications.assigned.count }.by(-2)
       end
     end


### PR DESCRIPTION
This fix addresses an issue if a group is deleted topics will remain
assigned to all group members with no way to un-assign those users from
the original group assignment.

Now if a group is deleted any group assignments are also deleted.
