### PR TITLE
FEATURE: better notification level on assign

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -312,15 +312,15 @@ class ::Assigner
     publish_assignment(assignment, assign_to, note, status)
 
     if assignment.assigned_to_user?
-      if !TopicUser.exists?(
-           user_id: assign_to.id,
-           topic_id: topic.id,
-           notification_level: TopicUser.notification_levels[:watching],
-         )
+      notification_level =
+        assign_to.user_option&.notification_level_when_replying ||
+          TopicUser.notification_levels[:watching]
+
+      if !TopicUser.exists?(user_id: assign_to.id, topic_id: topic.id, notification_level:)
         TopicUser.change(
           assign_to.id,
           topic.id,
-          notification_level: TopicUser.notification_levels[:watching],
+          notification_level:,
           notifications_reason_id: TopicUser.notification_reasons[:plugin_changed],
         )
       end


### PR DESCRIPTION
Use the "when I post in a topic, set that topic to..." user preference as the default notification level when a topic/post is assigned to a user instead of always setting it to "watching".