### PR TITLE
DEV: ensure bulk action is done before checking for result

### DIFF
--- a/spec/system/bulk_assign_spec.rb
+++ b/spec/system/bulk_assign_spec.rb
@@ -46,6 +46,7 @@ describe "Assign | Bulk Assign", type: :system do
 
       # Click Confirm
       topic_list_header.click_bulk_topics_confirm
+      expect(assign_modal).to be_closed
 
       # Reload and check that topic is now assigned
       visit "/latest"
@@ -65,6 +66,7 @@ describe "Assign | Bulk Assign", type: :system do
 
       # Click Confirm
       topic_list_header.click_bulk_topics_confirm
+      expect(assign_modal).to be_closed
 
       # Reload and check that topic is now assigned
       visit "/latest"

--- a/spec/system/page_objects/components/topic_list.rb
+++ b/spec/system/page_objects/components/topic_list.rb
@@ -4,11 +4,11 @@ module PageObjects
   module Components
     class TopicList < PageObjects::Components::Base
       def has_assigned_status?(topic)
-        page.has_css?("#{topic_list_item_assigned(topic)}", visible: :all)
+        try_until_success { page.has_css?("#{topic_list_item_assigned(topic)}") }
       end
 
       def has_unassigned_status?(topic)
-        page.has_no_css?("#{topic_list_item_assigned(topic)}", visible: :all)
+        try_until_success { page.has_no_css?("#{topic_list_item_assigned(topic)}") }
       end
 
       private

--- a/spec/system/page_objects/components/topic_list.rb
+++ b/spec/system/page_objects/components/topic_list.rb
@@ -4,11 +4,11 @@ module PageObjects
   module Components
     class TopicList < PageObjects::Components::Base
       def has_assigned_status?(topic)
-        try_until_success { page.has_css?("#{topic_list_item_assigned(topic)}") }
+        page.has_css?("#{topic_list_item_assigned(topic)}")
       end
 
       def has_unassigned_status?(topic)
-        try_until_success { page.has_no_css?("#{topic_list_item_assigned(topic)}") }
+        page.has_no_css?("#{topic_list_item_assigned(topic)}")
       end
 
       private

--- a/spec/system/page_objects/components/topic_list.rb
+++ b/spec/system/page_objects/components/topic_list.rb
@@ -4,11 +4,11 @@ module PageObjects
   module Components
     class TopicList < PageObjects::Components::Base
       def has_assigned_status?(topic)
-        page.has_css?("#{topic_list_item_assigned(topic)}")
+        page.has_css?("#{topic_list_item_assigned(topic)}", visible: :all)
       end
 
       def has_unassigned_status?(topic)
-        page.has_no_css?("#{topic_list_item_assigned(topic)}")
+        page.has_no_css?("#{topic_list_item_assigned(topic)}", visible: :all)
       end
 
       private


### PR DESCRIPTION
Sometimes the target topic can be out of the viewport and this was causing failing specs.