### PR TITLE
FEATURE: Add `should_notify` option to `Assigner#assign`

### DIFF
--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -44,12 +44,7 @@ module DiscourseAssign
       note = params.permit(:note)["note"].presence
       status = params.permit(:status)["status"].presence
       should_notify = params.permit(:should_notify)["should_notify"]
-      should_notify =
-        if should_notify.present?
-          should_notify == "true"
-        else
-          true
-        end
+      should_notify = (should_notify.present? ? should_notify == "true" : true)
 
       assign_to =
         (

--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -44,7 +44,7 @@ module DiscourseAssign
       note = params.permit(:note)["note"].presence
       status = params.permit(:status)["status"].presence
       should_notify = params.permit(:should_notify)["should_notify"]
-      should_notify = (should_notify.present? ? should_notify == "true" : true)
+      should_notify = (should_notify.present? ? should_notify.to_s == "true" : true)
 
       assign_to =
         (

--- a/app/controllers/discourse_assign/assign_controller.rb
+++ b/app/controllers/discourse_assign/assign_controller.rb
@@ -43,6 +43,13 @@ module DiscourseAssign
       group_name = params.permit(:group_name)["group_name"]
       note = params.permit(:note)["note"].presence
       status = params.permit(:status)["status"].presence
+      should_notify = params.permit(:should_notify)["should_notify"]
+      should_notify =
+        if should_notify.present?
+          should_notify == "true"
+        else
+          true
+        end
 
       assign_to =
         (
@@ -58,7 +65,13 @@ module DiscourseAssign
       target = target_type.constantize.where(id: target_id).first
       raise Discourse::NotFound unless target
 
-      assign = Assigner.new(target, current_user).assign(assign_to, note: note, status: status)
+      assign =
+        Assigner.new(target, current_user).assign(
+          assign_to,
+          note: note,
+          status: status,
+          should_notify: should_notify,
+        )
 
       if assign[:success]
         render json: success_json


### PR DESCRIPTION
This option let's you control whether the added user within a group assignment should be notified or not.

requires https://github.com/discourse/discourse/pull/29741 to ci go green