### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/assignment.gjs
+++ b/assets/javascripts/discourse/components/assignment.gjs
@@ -98,7 +98,7 @@ export default class Assignment extends Component {
 
       {{#if this.showAssigneeIeEmptyError}}
         <span class="error-label">
-          {{icon "exclamation-triangle"}}
+          {{icon "triangle-exclamation"}}
           {{i18n "discourse_assign.assign_modal.choose_assignee"}}
         </span>
       {{/if}}

--- a/assets/javascripts/discourse/components/topic-level-assign-menu.js
+++ b/assets/javascripts/discourse/components/topic-level-assign-menu.js
@@ -112,7 +112,7 @@ function extractPostId(buttonId) {
 }
 
 function editAssignmentsButton() {
-  const icon = iconHTML("pencil-alt");
+  const icon = iconHTML("pencil");
   const label = I18n.t("discourse_assign.topic_level_menu.edit_assignments");
   return {
     id: "reassign",
@@ -138,7 +138,7 @@ function unassignFromTopicButton(topic) {
     topic.assigned_to_user?.username || topic.assigned_to_group?.name;
   const icon = topic.assigned_to_user
     ? avatarHtml(topic.assigned_to_user, "small")
-    : iconHTML("user-times");
+    : iconHTML("user-xmark");
   const label = I18n.t(
     "discourse_assign.topic_level_menu.unassign_from_topic",
     { username }


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.