### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/assigned-to-post.gjs
+++ b/assets/javascripts/discourse/components/assigned-to-post.gjs
@@ -41,7 +41,7 @@ export default class AssignedToPost extends Component {
 
     <DMenu
       @identifier="post-assign-menu"
-      @icon="ellipsis-h"
+      @icon="ellipsis"
       class="btn-flat more-button"
       @autofocus={{true}}
     >


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.