### PR TITLE
DEV: fix specs with new mobile footer UI

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -159,16 +159,6 @@
   }
 }
 
-#topic-footer-button-assign {
-  padding-top: 0.35em;
-  padding-bottom: 0.35em;
-  .d-button-label {
-    .avatar {
-      margin-right: 0.25em;
-    }
-  }
-}
-
 #topic-footer-dropdown-reassign {
   .name {
     font-weight: normal;
@@ -196,7 +186,6 @@
 }
 
 // Group assigns sidebar nav
-
 .group-assignments {
   // a little extra space for long names
   min-width: 250px;

--- a/test/javascripts/acceptance/assign-disabled-test.js
+++ b/test/javascripts/acceptance/assign-disabled-test.js
@@ -1,7 +1,6 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Discourse Assign | Assign disabled mobile", function (needs) {
   needs.user({ can_assign: true });
@@ -10,10 +9,7 @@ acceptance("Discourse Assign | Assign disabled mobile", function (needs) {
 
   test("Footer dropdown does not contain button", async function (assert) {
     await visit("/t/internationalization-localization/280");
-
-    const menu = selectKit(".topic-footer-mobile-dropdown");
-    await menu.expand();
-
-    assert.false(menu.rowByValue("assign").exists());
+    await click(".topic-footer-mobile-dropdown-trigger");
+    assert.dom(".assign").doesNotExist();
   });
 });

--- a/test/javascripts/acceptance/assign-enabled-test.js
+++ b/test/javascripts/acceptance/assign-enabled-test.js
@@ -39,19 +39,14 @@ acceptance("Discourse Assign | Assign mobile", function (needs) {
   test("Footer dropdown contains button", async function (assert) {
     updateCurrentUser({ can_assign: true });
     await visit("/t/internationalization-localization/280");
-    const menu = selectKit(".topic-footer-mobile-dropdown");
-    await menu.expand();
-
-    assert.true(menu.rowByValue("assign").exists());
-    await menu.selectRowByValue("assign");
+    await click(".topic-footer-mobile-dropdown-trigger");
+    await click(".assign");
     assert.dom(".assign.d-modal").exists("assign modal opens");
   });
 });
 
 acceptance("Discourse Assign | Assign desktop", function (needs) {
-  needs.user({
-    can_assign: true,
-  });
+  needs.user({ can_assign: true });
   needs.settings({ glimmer_post_menu_mode: "enabled", assign_enabled: true });
 
   needs.pretender((server, helper) => {

--- a/test/javascripts/acceptance/assign-enabled-widget-post-menu-test.js
+++ b/test/javascripts/acceptance/assign-enabled-widget-post-menu-test.js
@@ -45,11 +45,8 @@ acceptance(
     test("Footer dropdown contains button", async function (assert) {
       updateCurrentUser({ can_assign: true });
       await visit("/t/internationalization-localization/280");
-      const menu = selectKit(".topic-footer-mobile-dropdown");
-      await menu.expand();
-
-      assert.true(menu.rowByValue("assign").exists());
-      await menu.selectRowByValue("assign");
+      await click(".topic-footer-mobile-dropdown-trigger");
+      await click(".assign");
       assert.dom(".assign.d-modal").exists("assign modal opens");
     });
   }

--- a/test/javascripts/acceptance/assigned-topic-test.js
+++ b/test/javascripts/acceptance/assigned-topic-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import {
@@ -220,14 +220,13 @@ acceptance("Discourse Assign | Reassign topic | mobile", function (needs) {
 
   test("Mobile Footer dropdown contains reassign buttons", async function (assert) {
     updateCurrentUser({ can_assign: true });
-    const menu = selectKit(".topic-footer-mobile-dropdown");
 
     await visit("/t/assignment-topic/44");
-    await menu.expand();
+    await click(".topic-footer-mobile-dropdown-trigger");
 
-    assert.true(menu.rowByValue("unassign-mobile").exists());
-    assert.true(menu.rowByValue("reassign-mobile").exists());
-    assert.true(menu.rowByValue("reassign-self-mobile").exists());
+    assert.dom("#topic-footer-button-unassign-mobile").exists();
+    assert.dom("#topic-footer-button-reassign-self-mobile").exists();
+    assert.dom("#topic-footer-button-reassign-mobile").exists();
   });
 });
 


### PR DESCRIPTION
Dependent on https://github.com/discourse/discourse/pull/30132 getting merged.

The UI for the "hidden" topic footer buttons on mobile changes from SelectKit to DMenu, so the specs needed to be updated as such.