### PR TITLE
FIX: Not send notifications when it should never notify assignment

### DIFF
--- a/app/jobs/regular/assign_notification.rb
+++ b/app/jobs/regular/assign_notification.rb
@@ -4,6 +4,7 @@ module Jobs
   class AssignNotification < ::Jobs::Base
     def execute(args)
       raise Discourse::InvalidParameters.new(:assignment_id) if args[:assignment_id].nil?
+      return if SilencedAssignment.exists?(assignment_id: args[:assignment_id])
       Assignment.find(args[:assignment_id]).create_missing_notifications!
     end
   end

--- a/app/models/silenced_assignment.rb
+++ b/app/models/silenced_assignment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SilencedAssignment < ActiveRecord::Base
+  belongs_to :assignment
+end

--- a/app/models/silenced_assignment.rb
+++ b/app/models/silenced_assignment.rb
@@ -3,3 +3,17 @@
 class SilencedAssignment < ActiveRecord::Base
   belongs_to :assignment
 end
+
+# == Schema Information
+#
+# Table name: silenced_assignments
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :bigint           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_silenced_assignments_on_assignment_id  (assignment_id) UNIQUE
+#

--- a/db/migrate/20241212113000_create_silenced_assignments.rb
+++ b/db/migrate/20241212113000_create_silenced_assignments.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class CreateSilencedAssignments < ActiveRecord::Migration[7.2]
+  def up
+    create_table :silenced_assignments do |t|
+      t.bigint :assignment_id, null: false
+      t.timestamps
+    end
+    add_index :silenced_assignments, :assignment_id, unique: true
+  end
+
+  def down
+    drop_table :silenced_assignments
+  end
+end

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -322,6 +322,10 @@ class ::Assigner
 
     first_post.publish_change_to_clients!(:revised, reload_topic: true)
     queue_notification(assignment) if should_notify
+
+    # This assignment should never be notified
+    SilencedAssignment.create!(assignment_id: assignment.id) if !should_notify
+
     publish_assignment(assignment, assign_to, note, status)
 
     if assignment.assigned_to_user?

--- a/spec/jobs/regular/assign_notification_spec.rb
+++ b/spec/jobs/regular/assign_notification_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Jobs::AssignNotification do
         assignment.expects(:create_missing_notifications!)
         execute_job
       end
+
+      it "does not create notifications if assignment is silenced" do
+        SilencedAssignment.stubs(:exists?).with(assignment_id: assignment_id).returns(true)
+        assignment.expects(:create_missing_notifications!).never
+        execute_job
+      end
     end
   end
 end

--- a/spec/lib/assigner_spec.rb
+++ b/spec/lib/assigner_spec.rb
@@ -794,6 +794,10 @@ RSpec.describe Assigner do
       assigner.assign(group, should_notify: false)
       expect(topic.allowed_groups).to include(group)
       expect(Notification.count).to eq(0)
+      expect(SilencedAssignment.count).to eq(1)
+
+      group.add(Fabricate(:user))
+      expect(Notification.count).to eq(0) # no one is ever notified about this assignment
     end
 
     it "doesn't invite group if all members have access to the PM already" do

--- a/spec/requests/assign_controller_spec.rb
+++ b/spec/requests/assign_controller_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe DiscourseAssign::AssignController do
     it "notifies the assignee when the topic is assigned to a group" do
       admins = Group[:admins]
       admins.messageable_level = Group::ALIAS_LEVELS[:everyone]
+      admins.assignable_level = Group::ALIAS_LEVELS[:everyone]
       admins.save!
 
       SiteSetting.invite_on_assign = true
@@ -290,6 +291,7 @@ RSpec.describe DiscourseAssign::AssignController do
     it "does not notify the assignee when the topic is assigned to a group if should_notify option is set to false" do
       admins = Group[:admins]
       admins.messageable_level = Group::ALIAS_LEVELS[:everyone]
+      admins.assignable_level = Group::ALIAS_LEVELS[:everyone]
       admins.save!
 
       SiteSetting.invite_on_assign = true
@@ -313,6 +315,7 @@ RSpec.describe DiscourseAssign::AssignController do
             should_notify: false,
           }
       expect(Notification.count).to eq(0)
+      expect(SilencedAssignment.count).to eq(1)
     end
 
     it "fails with a specific error message if the topic is not a PM and the assignee can not see it" do


### PR DESCRIPTION
- Added silenced_assignments table and migration to store silenced assignments
- Added tests for silenced assignments