### PR TITLE
DEV: make specs regarding assign button more lenient

### DIFF
--- a/test/javascripts/acceptance/assign-disabled-test.js
+++ b/test/javascripts/acceptance/assign-disabled-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -9,7 +9,6 @@ acceptance("Discourse Assign | Assign disabled mobile", function (needs) {
 
   test("Footer dropdown does not contain button", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click(".topic-footer-mobile-dropdown-trigger");
     assert.dom(".assign").doesNotExist();
   });
 });


### PR DESCRIPTION
in preparation of https://github.com/discourse/discourse/pull/30242 which might make the assign button appear immediately (when it's the only available option) or behind the "..." dropdown.