### PR TITLE
DEV: update deprecated icon name from user-times to user-xmark

### DIFF
--- a/assets/javascripts/discourse/components/assign-actions-dropdown.js
+++ b/assets/javascripts/discourse/components/assign-actions-dropdown.js
@@ -21,7 +21,7 @@ export default class AssignActionsDropdown extends DropdownSelectBoxComponent {
       options = options.concat([
         {
           id: "unassign",
-          icon: this.group ? "group-times" : "user-times",
+          icon: this.group ? "group-times" : "user-xmark",
           name: I18n.t("discourse_assign.unassign.title"),
           description: I18n.t("discourse_assign.unassign.help", {
             username: this.assignee,
@@ -42,7 +42,7 @@ export default class AssignActionsDropdown extends DropdownSelectBoxComponent {
         const assignee = assignment_map.assigned_to;
         options = options.concat({
           id: `unassign_post_${postId}`,
-          icon: assignee.username ? "user-times" : "group-times",
+          icon: assignee.username ? "user-xmark" : "group-times",
           name: I18n.t("discourse_assign.unassign_post.title"),
           description: I18n.t("discourse_assign.unassign_post.help", {
             username: assignee.username || assignee.name,

--- a/assets/javascripts/discourse/components/assign-button.gjs
+++ b/assets/javascripts/discourse/components/assign-button.gjs
@@ -15,7 +15,7 @@ export default class AssignButton extends Component {
   @service taskActions;
 
   get icon() {
-    return this.isAssigned ? "user-times" : "user-plus";
+    return this.isAssigned ? "user-xmark" : "user-plus";
   }
 
   get isAssigned() {

--- a/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -51,7 +51,7 @@ function registerTopicFooterButtons(api) {
     icon() {
       return this.topic.isAssigned()
         ? this.site.mobileView
-          ? "user-times"
+          ? "user-xmark"
           : null
         : "user-plus";
     },
@@ -150,7 +150,7 @@ function registerTopicFooterButtons(api) {
   api.registerTopicFooterButton({
     id: "unassign-mobile",
     icon() {
-      return "user-times";
+      return "user-xmark";
     },
     translatedTitle() {
       return defaultTitle(this.topic);
@@ -398,9 +398,9 @@ function initialize(api) {
   api.addPostSmallActionIcon("assigned_to_post", "user-plus");
   api.addPostSmallActionIcon("assigned_group", "group-plus");
   api.addPostSmallActionIcon("assigned_group_to_post", "group-plus");
-  api.addPostSmallActionIcon("unassigned", "user-times");
+  api.addPostSmallActionIcon("unassigned", "user-xmark");
   api.addPostSmallActionIcon("unassigned_group", "group-times");
-  api.addPostSmallActionIcon("unassigned_from_post", "user-times");
+  api.addPostSmallActionIcon("unassigned_from_post", "user-xmark");
   api.addPostSmallActionIcon("unassigned_group_from_post", "group-times");
   api.includePostAttributes("assigned_to_user", "assigned_to_group");
   api.addPostSmallActionIcon("reassigned", "user-plus");
@@ -777,7 +777,7 @@ function customizeWidgetPostMenu(api) {
     if (post.assigned_to_user || post.assigned_to_group) {
       return {
         action: "unassignPost",
-        icon: "user-times",
+        icon: "user-xmark",
         className: "unassign-post",
         title: "discourse_assign.unassign_post.title",
         position:
@@ -874,7 +874,7 @@ export default {
       api.addBulkActionButton({
         id: "unassign-topics",
         label: "topics.bulk.unassign",
-        icon: "user-times",
+        icon: "user-xmark",
         class: "btn-default unassign-topics",
         action({ performAndRefresh }) {
           performAndRefresh({ type: "unassign" });

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,7 +12,7 @@ enabled_site_setting :assign_enabled
 register_asset "stylesheets/assigns.scss"
 register_asset "stylesheets/mobile/assigns.scss", :mobile
 
-%w[user-plus user-times group-plus group-times].each { |i| register_svg_icon(i) }
+%w[user-plus user-xmark group-plus group-times].each { |i| register_svg_icon(i) }
 
 module ::DiscourseAssign
   PLUGIN_NAME = "discourse-assign"


### PR DESCRIPTION
This PR updates the deprecated `user-times` icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.

