### PR TITLE
DEV: update deprecated icon name search to magnifying-glass

### DIFF
--- a/assets/javascripts/discourse/components/assignment.gjs
+++ b/assets/javascripts/discourse/components/assignment.gjs
@@ -91,8 +91,8 @@ export default class Assignment extends Component {
           maximum=1
           tabindex=1
           expandedOnInsert=(not this.assignee)
-          caretUpIcon="search"
-          caretDownIcon="search"
+          caretUpIcon="magnifying-glass"
+          caretDownIcon="magnifying-glass"
         }}
       />
 


### PR DESCRIPTION
This PR updates the deprecated `search` icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.