### PR TITLE
FIX: skip notifications when topic is not found

### DIFF
--- a/lib/discourse_assign/create_notification.rb
+++ b/lib/discourse_assign/create_notification.rb
@@ -68,6 +68,7 @@ module DiscourseAssign
     end
 
     def call
+      return if topic.nil?
       Assigner.publish_topic_tracking_state(topic, user.id)
       unless mark_as_read?
         PostAlerter.new(post).create_notification_alert(

--- a/spec/lib/discourse_assign/create_notification_spec.rb
+++ b/spec/lib/discourse_assign/create_notification_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe DiscourseAssign::CreateNotification do
         create_notification
       end
 
+      context "when topic is not found" do
+        before { assignment.topic = nil }
+
+        it "does not publish topic tracking state" do
+          Assigner.expects(:publish_topic_tracking_state).never
+          create_notification
+        end
+
+        it "does not create a notification alert" do
+          alerter.expects(:create_notification_alert).never
+          create_notification
+        end
+      end
+
       context "when `mark_as_read` is false" do
         let(:excerpt) do
           I18n.t(


### PR DESCRIPTION
Fixes a bug where the topic may already be deleted before the notification job runs, causing the job to fail.