### PR TITLE
FIX: allow user to be assigned to post and topic

### DIFF
--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -554,16 +554,7 @@ class ::Assigner
   end
 
   def already_assigned?(assign_to, type, note, status)
-    return true if assignment_eq?(@target.assignment, assign_to, type, note, status)
-
-    # Check if the user is not assigned to any of the posts from the topic
-    # they will be assigned to.
-    if @target.is_a?(Topic)
-      assignments = Assignment.where(topic_id: topic.id, target_type: "Post", active: true)
-      return true if assignments.any? { |a| assignment_eq?(a, assign_to, type, note, status) }
-    end
-
-    false
+    assignment_eq?(@target.assignment, assign_to, type, note, status)
   end
 
   def reassign?

--- a/spec/integration/assign_spec.rb
+++ b/spec/integration/assign_spec.rb
@@ -149,7 +149,7 @@ describe "integration tests" do
 
     include_context "with group that is allowed to assign"
 
-    it "does not allow to assign topic if post is already assigned" do
+    it "allows to assign topic if post is already assigned" do
       add_to_assign_allowed_group(user)
 
       assigner = Assigner.new(post, user)
@@ -162,8 +162,7 @@ describe "integration tests" do
 
       assigner = Assigner.new(topic, user)
       response = assigner.assign(user)
-      expect(response[:success]).to be false
-      expect(response[:reason]).to eq(:already_assigned)
+      expect(response[:success]).to be true
     end
   end
 


### PR DESCRIPTION
This change makes it possible to assign the same user to both posts and the original topic.

/t/124663