### PR TITLE
UX: update for new core tag separator

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -11,6 +11,7 @@ import getURL from "discourse/lib/get-url";
 import { iconHTML, iconNode } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { registerTopicFooterDropdown } from "discourse/lib/register-topic-footer-dropdown";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { escapeExpression } from "discourse/lib/utilities";
 import RawHtml from "discourse/widgets/raw-html";
 import RenderGlimmer from "discourse/widgets/render-glimmer";
@@ -23,7 +24,6 @@ import BulkActionsAssignUser from "../components/bulk-actions/bulk-assign-user";
 import EditTopicAssignments from "../components/modal/edit-topic-assignments";
 import TopicLevelAssignMenu from "../components/topic-level-assign-menu";
 import { extendTopicModel } from "../models/topic";
-import { applyValueTransformer } from "discourse/lib/transformer";
 
 const DEPENDENT_KEYS = [
   "topic.assigned_to_user",

--- a/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -23,6 +23,7 @@ import BulkActionsAssignUser from "../components/bulk-actions/bulk-assign-user";
 import EditTopicAssignments from "../components/modal/edit-topic-assignments";
 import TopicLevelAssignMenu from "../components/topic-level-assign-menu";
 import { extendTopicModel } from "../models/topic";
+import { applyValueTransformer } from "discourse/lib/transformer";
 
 const DEPENDENT_KEYS = [
   "topic.assigned_to_user",
@@ -467,28 +468,52 @@ function initialize(api) {
       .filter(({ assignee }) => assignee)
       .flat();
 
-    if (assignedTo) {
-      return assignedTo
-        .map(({ assignee, note }) => {
-          let assignedPath;
-          if (assignee.assignedToPostId) {
-            assignedPath = `/p/${assignee.assignedToPostId}`;
-          } else {
-            assignedPath = `/t/${topic.id}`;
-          }
-          const icon = iconHTML(assignee.username ? "user-plus" : "group-plus");
-          const name = assignee.username || assignee.name;
-          const tagName = params.tagName || "a";
-          const href =
-            tagName === "a"
-              ? `href="${getURL(assignedPath)}" data-auto-route="true"`
-              : "";
-          return `<${tagName} class="assigned-to discourse-tag simple" ${href}>${icon}<span title="${escapeExpression(
-            note
-          )}">${name}</span></${tagName}>`;
-        })
-        .join("");
+    if (!assignedTo) {
+      return "";
     }
+
+    const createTagHtml = ({ assignee, note }) => {
+      let assignedPath;
+      if (assignee.assignedToPostId) {
+        assignedPath = `/p/${assignee.assignedToPostId}`;
+      } else {
+        assignedPath = `/t/${topic.id}`;
+      }
+
+      const icon = iconHTML(assignee.username ? "user-plus" : "group-plus");
+      const name = assignee.username || assignee.name;
+      const tagName = params.tagName || "a";
+      const href =
+        tagName === "a"
+          ? `href="${getURL(assignedPath)}" data-auto-route="true"`
+          : "";
+
+      return `<${tagName} class="assigned-to discourse-tag simple" ${href}>${icon}<span title="${escapeExpression(
+        note
+      )}">${name}</span></${tagName}>`;
+    };
+
+    // is there's one assignment just return the tag
+    if (assignedTo.length === 1) {
+      return createTagHtml(assignedTo[0]);
+    }
+
+    // join multiple assignments with a separator
+    let result = "";
+    assignedTo.forEach((assignment, index) => {
+      result += createTagHtml(assignment);
+
+      // add separator if not the last tag
+      if (index < assignedTo.length - 1) {
+        const separator = applyValueTransformer("tag-separator", ",", {
+          topic,
+          index,
+        });
+        result += `<span class="discourse-tags__tag-separator">${separator}</span>`;
+      }
+    });
+
+    return result;
   });
 
   api.createWidget("assigned-to-post", {


### PR DESCRIPTION
This works alongside https://github.com/discourse/discourse/commit/55a3a4e69ed75b055fb4907ac5370cf1519276c6 to add a customizable tag separator between multiple assigns. This replaces the previous commas implemented in CSS 


Before:

![image](https://github.com/user-attachments/assets/7eab6e0c-5b0b-4bdb-a4f7-a16588c522c3)


After:

![image](https://github.com/user-attachments/assets/29760c77-ef96-4591-9a33-21f73b28d40f)
