### PR TITLE
DEV: Remove code that is not necessary

### DIFF
--- a/spec/system/bulk_assign_spec.rb
+++ b/spec/system/bulk_assign_spec.rb
@@ -39,7 +39,6 @@ describe "Assign | Bulk Assign", type: :system do
       # opening with `is-expanded` property, but it isn't actually expanded.
       select_kit.collapse
 
-      select_kit.expand_if_needed
       select_kit.search(assignee)
       select_kit.select_row_by_value(assignee)
       select_kit.collapse

--- a/spec/system/group_assigned_spec.rb
+++ b/spec/system/group_assigned_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe "Assign | Group assigned", type: :system, js: true do
     # opening with `is-expanded` property, but it isn't actually expanded.
     select_kit.collapse
 
-    select_kit.expand_if_needed
     select_kit.search(assignee)
     select_kit.select_row_by_value(assignee)
     select_kit.collapse


### PR DESCRIPTION
Calling `expand_if_needed` is not necessary here.
