### PR TITLE
FIX: Incorrect ussage of prioritize_full_name_in_ux replaced by prioritize_username_in_ux

### DIFF
--- a/assets/javascripts/discourse/components/assigned-to-post.gjs
+++ b/assets/javascripts/discourse/components/assigned-to-post.gjs
@@ -12,7 +12,7 @@ export default class AssignedToPost extends Component {
   @service siteSettings;
 
   get nameOrUsername() {
-    if (this.siteSettings.prioritize_full_name_in_ux) {
+    if (!this.siteSettings.prioritize_username_in_ux) {
       return this.args.assignedToUser.name || this.args.assignedToUser.username;
     } else {
       return this.args.assignedToUser.username;

--- a/assets/javascripts/discourse/components/topic-level-assign-menu.js
+++ b/assets/javascripts/discourse/components/topic-level-assign-menu.js
@@ -75,7 +75,7 @@ export default {
       content.push(
         unassignFromTopicButton(
           this.topic,
-          this.siteSettings.prioritize_full_name_in_ux
+          this.siteSettings.prioritize_username_in_ux
         )
       );
     }
@@ -136,11 +136,11 @@ function reassignToSelfButton() {
   };
 }
 
-function unassignFromTopicButton(topic, prioritize_full_name_in_ux) {
+function unassignFromTopicButton(topic, prioritize_username_in_ux) {
   let username =
     topic.assigned_to_user?.username || topic.assigned_to_group?.name;
 
-  if (topic.assigned_to_user && prioritize_full_name_in_ux) {
+  if (topic.assigned_to_user && !prioritize_username_in_ux) {
     username = topic.assigned_to_user?.name || topic.assigned_to_user?.username;
   }
 

--- a/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -483,7 +483,7 @@ function initialize(api) {
 
       const icon = iconHTML(assignee.username ? "user-plus" : "group-plus");
       const name =
-        siteSettings.prioritize_full_name_in_ux || !assignee.username
+        siteSettings.prioritize_username_in_ux || !assignee.username
           ? assignee.name || assignee.username
           : assignee.username;
 
@@ -560,7 +560,7 @@ function initialize(api) {
 
       let displayedName = "";
       if (assignedToUser) {
-        displayedName = this.siteSettings.prioritize_full_name_in_ux
+        displayedName = !this.siteSettings.prioritize_username_in_ux
           ? assignedToUser.name || assignedToUser.username
           : assignedToUser.username;
 
@@ -598,7 +598,7 @@ function initialize(api) {
           const postNumber = indirectlyAssignedTo[postId].post_number;
 
           displayedName =
-            this.siteSettings.prioritize_full_name_in_ux || !assignee.username
+            !this.siteSettings.prioritize_username_in_ux || !assignee.username
               ? assignee.name || assignee.username
               : assignee.username;
 

--- a/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -483,7 +483,7 @@ function initialize(api) {
 
       const icon = iconHTML(assignee.username ? "user-plus" : "group-plus");
       const name =
-        siteSettings.prioritize_username_in_ux || !assignee.username
+        !siteSettings.prioritize_username_in_ux || !assignee.username
           ? assignee.name || assignee.username
           : assignee.username;
 

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -492,7 +492,7 @@ class ::Assigner
   end
 
   def small_action_username_or_name(assign_to)
-    if (assign_to.is_a?(User) && SiteSetting.prioritize_full_name_in_ux) ||
+    if (assign_to.is_a?(User) && !SiteSetting.prioritize_username_in_ux) ||
          !assign_to.try(:username)
       custom_fields = { "action_code_who" => assign_to.name || assign_to.username }
     else

--- a/spec/system/assign_post_spec.rb
+++ b/spec/system/assign_post_spec.rb
@@ -11,8 +11,7 @@ describe "Assign | Assigning posts", type: :system do
 
   before do
     SiteSetting.assign_enabled = true
-    SiteSetting.prioritize_full_name_in_ux = false
-
+    SiteSetting.prioritize_username_in_ux = true
     # The system tests in this file are flaky and auth token related so turning this on
     SiteSetting.verbose_auth_token_logging = true
 
@@ -26,8 +25,6 @@ describe "Assign | Assigning posts", type: :system do
   end
 
   describe "with open topic" do
-    before { SiteSetting.prioritize_full_name_in_ux = false }
-
     it "can assign and unassign" do
       visit "/t/#{topic.id}"
       assign_post(post2, staff_user)
@@ -63,7 +60,7 @@ describe "Assign | Assigning posts", type: :system do
     end
 
     context "when prioritize_full_name_in_ux setting is enabled" do
-      before { SiteSetting.prioritize_full_name_in_ux = true }
+      before { SiteSetting.prioritize_username_in_ux = false }
 
       it "shows the user's name after assign" do
         visit "/t/#{topic.id}"

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -10,7 +10,6 @@ describe "Assign | Assigning topics", type: :system do
 
   before do
     SiteSetting.assign_enabled = true
-    SiteSetting.prioritize_full_name_in_ux = false
 
     # The system tests in this file are flaky and auth token related so turning this on
     SiteSetting.verbose_auth_token_logging = true
@@ -51,7 +50,7 @@ describe "Assign | Assigning topics", type: :system do
     end
 
     context "when prioritize_full_name_in_ux setting is enabled" do
-      before { SiteSetting.prioritize_full_name_in_ux = true }
+      before { SiteSetting.prioritize_username_in_ux = false }
 
       it "shows the user's name after assign" do
         visit "/t/#{topic.id}"


### PR DESCRIPTION
The `prioritize_username_in_ux ` site setting is more appropriate since `prioritize_full_name_in_ux ` is used for notifications and is a hidden setting.

![imagen](https://github.com/user-attachments/assets/b47c1f5b-313c-49ca-8189-9e9f866423bf)
