### PR TITLE
UX: following 08d99dc, we can remove the separate color assignment

### DIFF
--- a/assets/stylesheets/assigns.scss
+++ b/assets/stylesheets/assigns.scss
@@ -252,10 +252,6 @@
   }
 }
 
-.assigned-to.discourse-tag.simple {
-  color: var(--primary-medium);
-}
-
 .assigned-topic-list-header .topic-list-data.num:last-of-type {
   margin-right: 50px; // account for button in topic-list-items in topic-list-refactor
 }


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/08d99dc44a33b4c9f53ad531693f3db694073a03, tag text color assignments were simplified 

Assign tag colors were a little inconsistent due to core styling conflicts, but now that they're cleaned up the assign tag colors should match throughout the app without this additional style

Examples: 

![image](https://github.com/user-attachments/assets/6aefefdf-dd59-4296-9da8-91c29dd32d9b)

![image](https://github.com/user-attachments/assets/22da0283-5140-4fb8-b3a7-932a0c9cd66f)

![image](https://github.com/user-attachments/assets/5eae2352-ce16-4787-875f-042774d26319)

![image](https://github.com/user-attachments/assets/ef0c280c-84dd-47b8-96ef-756c099e41c4)


