### PR TITLE
FEATURE: add "assigned:<name>" filter (in the /filter page)

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -888,11 +888,11 @@ after_initialize do
   end
 
   add_filter_custom_filter("assigned") do |scope, filter_values, guardian|
-    return if !guardian.can_assign? || filter_values.blank?
+    next if !guardian.can_assign? || filter_values.blank?
 
     user_or_group_name = filter_values.compact.first
 
-    return if user_or_group_name.blank?
+    next if user_or_group_name.blank?
 
     if user_id = User.find_by_username(user_or_group_name)&.id
       scope.where(<<~SQL, user_id)
@@ -906,19 +906,19 @@ after_initialize do
   end
 
   register_search_advanced_filter(/in:assigned/) do |posts|
-    return if !@guardian.can_assign?
+    next if !@guardian.can_assign?
 
     posts.where("topics.id IN (SELECT a.topic_id FROM assignments a WHERE a.active)")
   end
 
   register_search_advanced_filter(/in:unassigned/) do |posts|
-    return if !@guardian.can_assign?
+    next if !@guardian.can_assign?
 
     posts.where("topics.id NOT IN (SELECT a.topic_id FROM assignments a WHERE a.active)")
   end
 
   register_search_advanced_filter(/assigned:(.+)$/) do |posts, match|
-    return if !@guardian.can_assign? || match.blank?
+    next if !@guardian.can_assign? || match.blank?
 
     if user_id = User.find_by_username(match)&.id
       posts.where(<<~SQL, user_id)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -355,4 +355,42 @@ describe ListController do
       expect(JSON.parse(response.body)["topic_list"]["topics"].map { |t| t["id"] }).to eq([pm.id])
     end
   end
+
+  describe "#filter" do
+    include_context "with group that is allowed to assign"
+
+    fab!(:group) { Fabricate(:group, assignable_level: Group::ALIAS_LEVELS[:mods_and_admins]) }
+
+    fab!(:topic_1) { Fabricate(:topic) }
+    fab!(:topic_2) { Fabricate(:topic) }
+    fab!(:topic_3) { Fabricate(:topic) }
+
+    fab!(:post_1) { Fabricate(:post, topic: topic_1) }
+    fab!(:post_2) { Fabricate(:post, topic: topic_2) }
+    fab!(:post_3) { Fabricate(:post, topic: topic_3) }
+
+    before do
+      sign_in(admin)
+    end
+
+    it "filters topics by assigned user" do
+      add_to_assign_allowed_group(user)
+
+      Assigner.new(topic_1, admin).assign(user)
+
+      get "/filter", params: { q: "assigned:#{user.username_lower}", format: :json }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.dig("topic_list", "topics").map { _1["id"] }).to contain_exactly(topic_1.id)
+    end
+
+    it "filters topics by assigned group" do
+      Assigner.new(topic_2, admin).assign(group)
+
+      get "/filter", params: { q: "assigned:#{group.name}", format: :json }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.dig("topic_list", "topics").map { _1["id"] }).to contain_exactly(topic_2.id)
+    end
+  end
 end


### PR DESCRIPTION
The "assigned:\<name\>" filter was already available in the advanced search but it wasn't in the /filter page.

This commit adds that filter allowing anyone to filter topics assigned to either a specific user (using their username) or to a specific group (using its name).