### PR TITLE
UX: Add class to assign topic list items

### DIFF
--- a/assets/javascripts/discourse/initializers/assignment-list-actions.gjs
+++ b/assets/javascripts/discourse/initializers/assignment-list-actions.gjs
@@ -29,6 +29,15 @@ export default {
           return columns;
         }
       );
+      api.registerValueTransformer(
+        "topic-list-item-class",
+        ({ value: classes }) => {
+          if (ASSIGN_LIST_ROUTES.includes(router.currentRouteName)) {
+            classes.push("assigned-list-item");
+          }
+          return classes;
+        }
+      );
     });
   },
 };


### PR DESCRIPTION
This PR will add the `assigned-list-item` class to the topic-list-item when on a route that is included in `ASSIGN_LIST_ROUTES`.