### PR TITLE
DEV: Tweak has_content? check

### DIFF
--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -67,7 +67,7 @@ module PageObjects
           post_content.gsub!(%r{<a[^>]*>(.*?)</a>}, '\1')
         end
 
-        container.has_content?(post_content)
+        container.has_content?(:all, post_content)
       end
     end
   end


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/32145 in core
changes the mentions a bit and introduces inline-flex,
which means that part of the content is not visible according
to capybara. Checking for `:all` fixes this.
