### PR TITLE
DEV: Temporarily revert prioritize_username_in_ux for prioritize_full_name_in_ux

### DIFF
--- a/assets/javascripts/discourse/components/assigned-to-post.gjs
+++ b/assets/javascripts/discourse/components/assigned-to-post.gjs
@@ -12,7 +12,7 @@ export default class AssignedToPost extends Component {
   @service siteSettings;
 
   get nameOrUsername() {
-    if (!this.siteSettings.prioritize_username_in_ux) {
+    if (this.siteSettings.prioritize_full_name_in_ux) {
       return this.args.assignedToUser.name || this.args.assignedToUser.username;
     } else {
       return this.args.assignedToUser.username;

--- a/assets/javascripts/discourse/components/topic-level-assign-menu.js
+++ b/assets/javascripts/discourse/components/topic-level-assign-menu.js
@@ -75,7 +75,7 @@ export default {
       content.push(
         unassignFromTopicButton(
           this.topic,
-          this.siteSettings.prioritize_username_in_ux
+          this.siteSettings.prioritize_full_name_in_ux
         )
       );
     }
@@ -136,11 +136,11 @@ function reassignToSelfButton() {
   };
 }
 
-function unassignFromTopicButton(topic, prioritize_username_in_ux) {
+function unassignFromTopicButton(topic, prioritize_full_name_in_ux) {
   let username =
     topic.assigned_to_user?.username || topic.assigned_to_group?.name;
 
-  if (topic.assigned_to_user && !prioritize_username_in_ux) {
+  if (topic.assigned_to_user && prioritize_full_name_in_ux) {
     username = topic.assigned_to_user?.name || topic.assigned_to_user?.username;
   }
 

--- a/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -478,8 +478,9 @@ function initialize(api) {
       }
 
       const icon = iconHTML(assignee.username ? "user-plus" : "group-plus");
+      const showNameInUx = siteSettings.prioritize_full_name_in_ux;
       const name =
-        !siteSettings.prioritize_username_in_ux || !assignee.username
+        showNameInUx || !assignee.username
           ? assignee.name || assignee.username
           : assignee.username;
 
@@ -556,7 +557,7 @@ function initialize(api) {
 
       let displayedName = "";
       if (assignedToUser) {
-        displayedName = !this.siteSettings.prioritize_username_in_ux
+        displayedName = this.siteSettings.prioritize_full_name_in_ux
           ? assignedToUser.name || assignedToUser.username
           : assignedToUser.username;
 
@@ -594,7 +595,7 @@ function initialize(api) {
           const postNumber = indirectlyAssignedTo[postId].post_number;
 
           displayedName =
-            !this.siteSettings.prioritize_username_in_ux || !assignee.username
+            this.siteSettings.prioritize_full_name_in_ux || !assignee.username
               ? assignee.name || assignee.username
               : assignee.username;
 

--- a/lib/assigner.rb
+++ b/lib/assigner.rb
@@ -492,7 +492,7 @@ class ::Assigner
   end
 
   def small_action_username_or_name(assign_to)
-    if (assign_to.is_a?(User) && !SiteSetting.prioritize_username_in_ux) ||
+    if (assign_to.is_a?(User) && SiteSetting.prioritize_full_name_in_ux) ||
          !assign_to.try(:username)
       custom_fields = { "action_code_who" => assign_to.name || assign_to.username }
     else

--- a/spec/system/assign_post_spec.rb
+++ b/spec/system/assign_post_spec.rb
@@ -12,7 +12,7 @@ describe "Assign | Assigning posts", type: :system do
   before do
     skip "Tests are broken and need to be fixed. See https://github.com/discourse/discourse/actions/runs/13890376408/job/38861216842"
     SiteSetting.assign_enabled = true
-    SiteSetting.prioritize_username_in_ux = true
+    SiteSetting.prioritize_full_name_in_ux = false
     # The system tests in this file are flaky and auth token related so turning this on
     SiteSetting.verbose_auth_token_logging = true
 
@@ -61,7 +61,7 @@ describe "Assign | Assigning posts", type: :system do
     end
 
     context "when prioritize_full_name_in_ux setting is enabled" do
-      before { SiteSetting.prioritize_username_in_ux = false }
+      before { SiteSetting.prioritize_full_name_in_ux = true }
 
       it "shows the user's name after assign" do
         visit "/t/#{topic.id}"

--- a/spec/system/assign_topic_spec.rb
+++ b/spec/system/assign_topic_spec.rb
@@ -10,7 +10,7 @@ describe "Assign | Assigning topics", type: :system do
 
   before do
     SiteSetting.assign_enabled = true
-
+    SiteSetting.prioritize_full_name_in_ux = false
     # The system tests in this file are flaky and auth token related so turning this on
     SiteSetting.verbose_auth_token_logging = true
 
@@ -50,7 +50,7 @@ describe "Assign | Assigning topics", type: :system do
     end
 
     context "when prioritize_full_name_in_ux setting is enabled" do
-      before { SiteSetting.prioritize_username_in_ux = false }
+      before { SiteSetting.prioritize_full_name_in_ux = true }
 
       it "shows the user's name after assign" do
         visit "/t/#{topic.id}"


### PR DESCRIPTION
**Problem**
Part of this code is not wanted in production yet. To avoid causing issues we want to revert to using the `prioritize_full_name_in_ux` site setting 